### PR TITLE
Add source parameter to the connection

### DIFF
--- a/mvicore-android/src/main/java/com/badoo/mvicore/android/AndroidBindings.kt
+++ b/mvicore-android/src/main/java/com/badoo/mvicore/android/AndroidBindings.kt
@@ -2,8 +2,8 @@ package com.badoo.mvicore.android
 
 import android.arch.lifecycle.LifecycleOwner
 import com.badoo.mvicore.binder.Binder
-import com.badoo.mvicore.binder.lifecycle.Lifecycle as BinderLifecycle
 import android.arch.lifecycle.Lifecycle as AndroidLifecycle
+import com.badoo.mvicore.binder.lifecycle.Lifecycle as BinderLifecycle
 
 abstract class AndroidBindings<T : Any>(
     lifecycleOwner: LifecycleOwner

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
@@ -36,7 +36,7 @@ class Binder(
             Connection(
                 from = connection.first,
                 to = connection.second,
-                transformer = { it }
+                transformer = null
             )
         )
     }
@@ -98,7 +98,9 @@ class Binder(
     private fun <Out: Any, In: Any> Observable<Out>.applyTransformer(
         connection: Connection<Out, In>
     ): Observable<In> =
-        mapNotNull(connection.transformer ?: { it as? In })
+        connection.transformer?.let {
+            mapNotNull(it)
+        } ?: this as Observable<In>
 
     // endregion
 

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
@@ -82,7 +82,7 @@ class Binder(
     ): Disposable =
         applyTransformer(connection)
             .run {
-                middleware?.let {
+                if (middleware != null) {
                     middleware.onBind(connection)
 
                     this
@@ -90,7 +90,9 @@ class Binder(
                         .doFinally { middleware.onComplete(connection) }
                         .subscribe(middleware)
 
-                } ?: subscribe(connection.to)
+                } else {
+                    subscribe(connection.to)
+                }
             }
 
     private fun <Out: Any, In: Any> Observable<Out>.applyTransformer(

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
@@ -5,9 +5,10 @@ import io.reactivex.Observable
 import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 
-data class Connection<T>(
-    val from: ObservableSource<out T>? = null,
-    val to: Consumer<T>,
+data class Connection<Out, In>(
+    val from: ObservableSource<Out>? = null,
+    val to: Consumer<In>,
+    val transformer: ((Out) -> In?)? = null,
     val name: String? = null
 ) {
     companion object {
@@ -21,22 +22,21 @@ data class Connection<T>(
         "<${name ?: ANONYMOUS}> (${from ?: "?"} --> $to)"
 }
 
-infix fun <Out, In> Pair<ObservableSource<out Out>, Consumer<In>>.using(transformer: (Out) -> In?): Connection<In> =
+infix fun <Out, In> Pair<ObservableSource<Out>, Consumer<In>>.using(transformer: (Out) -> In?): Connection<Out, In> =
     Connection(
-        from = Observable
-            .wrap(first)
-            .mapNotNull(transformer),
-        to = second
+        from = first,
+        to = second,
+        transformer = transformer
     )
 
-infix fun <T> Pair<ObservableSource<out T>, Consumer<T>>.named(name: String): Connection<T> =
+infix fun <T> Pair<ObservableSource<T>, Consumer<T>>.named(name: String): Connection<T, T> =
     Connection(
         from = first,
         to = second,
         name = name
     )
 
-infix fun <T> Connection<T>.named(name: String) =
+infix fun <Out, In> Connection<Out, In>.named(name: String) =
     copy(
         name = name
     )

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
@@ -1,7 +1,5 @@
 package com.badoo.mvicore.binder
 
-import com.badoo.mvicore.extension.mapNotNull
-import io.reactivex.Observable
 import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
@@ -17,7 +17,7 @@ data class Connection<Out, In>(
         name == null
 
     override fun toString(): String =
-        "<${name ?: ANONYMOUS}> (${from ?: "?"} --> $to)"
+        "<${name ?: ANONYMOUS}> (${from ?: "?"} --> $to${transformer?.let { " using $it" } ?: ""})"
 }
 
 infix fun <Out, In> Pair<ObservableSource<Out>, Consumer<In>>.using(transformer: (Out) -> In?): Connection<Out, In> =

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/lifecycle/Lifecycle.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/lifecycle/Lifecycle.kt
@@ -1,7 +1,6 @@
 package com.badoo.mvicore.binder.lifecycle
 
 import com.badoo.mvicore.binder.lifecycle.internal.FromObservableSource
-import io.reactivex.Observable
 import io.reactivex.ObservableSource
 
 interface Lifecycle : ObservableSource<Lifecycle.Event> {

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
@@ -36,7 +36,7 @@ fun <In : Any> Consumer<In>.wrapWithMiddleware(
 
     if (current is Middleware<*, *> && standalone) {
         return StandaloneMiddleware(
-            wrappedMiddleware = current as Middleware<Any, In>,
+            wrappedMiddleware = current as Middleware<In, In>,
             name = name ?: wrapperOf?.javaClass?.canonicalName,
             postfix = postfix
         )

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
@@ -1,6 +1,7 @@
 package com.badoo.mvicore.consumer
 
-import com.badoo.mvicore.consumer.middleware.ConsumerMiddleware
+import com.badoo.mvicore.consumer.middleware.base.Middleware
+import com.badoo.mvicore.consumer.middleware.base.StandaloneMiddleware
 import com.badoo.mvicore.consumer.middlewareconfig.Middlewares
 import com.badoo.mvicore.consumer.middlewareconfig.NonWrappable
 import io.reactivex.functions.Consumer
@@ -18,12 +19,12 @@ import io.reactivex.functions.Consumer
  * @param postfix       Passed on to [ConsumerMiddleware], in most cases you shouldn't need to override this.
  * @param wrapperOf     Passed on to [ConsumerMiddleware], in most cases you shouldn't need to override this.
  */
-fun <T : Any> Consumer<T>.wrap(
+fun <In : Any> Consumer<In>.wrapWithMiddleware(
     standalone: Boolean = true,
     name: String? = null,
     postfix: String? = null,
     wrapperOf: Any? = null
-): Consumer<T> {
+): Consumer<In> {
     val target = wrapperOf ?: this
     if (target is NonWrappable) return this
 
@@ -33,10 +34,10 @@ fun <T : Any> Consumer<T>.wrap(
         current = it.applyOn(current, target, name, standalone)
     }
 
-    if (current is ConsumerMiddleware<T> && standalone) {
-        (current as ConsumerMiddleware<T>).initAsStandalone(
-            name = name,
-            wrapperOf = target,
+    if (current is Middleware<*, *> && standalone) {
+        StandaloneMiddleware(
+            wrappedMiddleware = current as Middleware<Any, In>,
+            name = name ?: wrapperOf?.javaClass?.canonicalName,
             postfix = postfix
         )
     }

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
@@ -35,7 +35,7 @@ fun <In : Any> Consumer<In>.wrapWithMiddleware(
     }
 
     if (current is Middleware<*, *> && standalone) {
-        StandaloneMiddleware(
+        return StandaloneMiddleware(
             wrappedMiddleware = current as Middleware<Any, In>,
             name = name ?: wrapperOf?.javaClass?.canonicalName,
             postfix = postfix

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
@@ -44,3 +44,22 @@ fun <In : Any> Consumer<In>.wrapWithMiddleware(
 
     return current
 }
+
+@Deprecated(
+    "Use wrapWithMiddleware directly",
+    ReplaceWith(
+        "wrapWithMiddleware(standalone, name, postfix, wrapperOf)",
+        "com.badoo.mvicore.consumer.wrapWithMiddleware"
+    )
+)
+fun <In: Any> Consumer<In>.wrap(
+    standalone: Boolean = true,
+    name: String? = null,
+    postfix: String? = null,
+    wrapperOf: Any? = null
+) = wrapWithMiddleware(
+    standalone,
+    name,
+    postfix,
+    wrapperOf
+)

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/ConsumerMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/ConsumerMiddleware.kt
@@ -1,74 +1,9 @@
 package com.badoo.mvicore.consumer.middleware
 
-import com.badoo.mvicore.binder.Connection
-import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Consumer
+import com.badoo.mvicore.consumer.middleware.base.Middleware
 
-abstract class ConsumerMiddleware<T : Any>(
-    protected val wrapped: Consumer<T>
-) : Consumer<T>, Disposable {
-
-    protected val innerMost = innerMost()
-    private var standaloneConnection: Connection<T>? = null
-    private var standaloneConnectionDisposed: Boolean = false
-
-    private fun innerMost(): Consumer<T> {
-        var current = wrapped
-        while (current is ConsumerMiddleware<T>) {
-            current = current.wrapped
-        }
-
-        return current
-    }
-
-    fun initAsStandalone(name: String? = null, wrapperOf: Any? = null, postfix: String?) {
-        standaloneConnection = Connection(
-            to = innerMost,
-            name = name ?: "${(wrapperOf ?: innerMost).javaClass.canonicalName}.${postfix ?: "input"}"
-        ).also {
-            onBind(it)
-        }
-    }
-
-    private fun check(connection: Connection<T>) {
-        if (standaloneConnection != null && connection != standaloneConnection) {
-            throw IllegalStateException("Middleware was initialised in standalone mode, can't accept other connections")
-        }
-    }
-
-    open fun onBind(connection: Connection<T>) {
-        check(connection)
-        if (wrapped is ConsumerMiddleware) {
-            wrapped.onBind(connection)
-        }
-    }
-
-    override fun accept(t: T) {
-        standaloneConnection?.let { onElement(it, t) }
-        innerMost.accept(t)
-    }
-
-    open fun onElement(connection: Connection<T>, element: T) {
-        check(connection)
-        if (wrapped is ConsumerMiddleware) {
-            wrapped.onElement(connection, element)
-        }
-    }
-
-    open fun onComplete(connection: Connection<T>) {
-        check(connection)
-        if (wrapped is ConsumerMiddleware) {
-            wrapped.onComplete(connection)
-        }
-    }
-
-    override fun dispose() {
-        standaloneConnection?.let {
-            onComplete(it)
-            standaloneConnectionDisposed = true
-        }
-    }
-
-    override fun isDisposed(): Boolean =
-        standaloneConnection == null || standaloneConnectionDisposed
-}
+@Deprecated(
+    "Left for compatibility reasons",
+    ReplaceWith("Middleware<Any, T>", "com.badoo.mvicore.consumer.middleware.base")
+)
+typealias ConsumerMiddleware<T> = Middleware<Any, T>

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
@@ -6,11 +6,11 @@ import com.badoo.mvicore.consumer.util.Logger
 import io.reactivex.functions.Consumer
 import java.util.*
 
-class LoggingMiddleware<T : Any>(
-    wrapped: Consumer<T>,
+class LoggingMiddleware<Out: Any, In: Any>(
+    wrapped: Consumer<In>,
     private val logger: Logger,
     private val config: Config = Config()
-) : Middleware<Any, T>(wrapped) {
+) : Middleware<Out, In>(wrapped) {
 
     data class Config(
         val locale: Locale = Locale.US,
@@ -24,17 +24,17 @@ class LoggingMiddleware<T : Any>(
         logger("${config.tag}: $message")
     }
 
-    override fun onBind(connection: Connection<Any, T>) {
+    override fun onBind(connection: Connection<Out, In>) {
         super.onBind(connection)
         log(config.onBindTemplate.format(config.locale, connection))
     }
 
-    override fun onElement(connection: Connection<Any, T>, element: T) {
+    override fun onElement(connection: Connection<Out, In>, element: In) {
         super.onElement(connection, element)
         log(config.onElementTemplate.format(config.locale, connection, element))
     }
 
-    override fun onComplete(connection: Connection<Any, T>) {
+    override fun onComplete(connection: Connection<Out, In>) {
         super.onComplete(connection)
         log(config.onCompleteTemplate.format(config.locale, connection))
     }

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
@@ -4,7 +4,7 @@ import com.badoo.mvicore.binder.Connection
 import com.badoo.mvicore.consumer.middleware.base.Middleware
 import com.badoo.mvicore.consumer.util.Logger
 import io.reactivex.functions.Consumer
-import java.util.Locale
+import java.util.*
 
 class LoggingMiddleware<T : Any>(
     wrapped: Consumer<T>,

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
@@ -1,6 +1,7 @@
 package com.badoo.mvicore.consumer.middleware
 
 import com.badoo.mvicore.binder.Connection
+import com.badoo.mvicore.consumer.middleware.base.Middleware
 import com.badoo.mvicore.consumer.util.Logger
 import io.reactivex.functions.Consumer
 import java.util.Locale
@@ -9,7 +10,7 @@ class LoggingMiddleware<T : Any>(
     wrapped: Consumer<T>,
     private val logger: Logger,
     private val config: Config = Config()
-) : ConsumerMiddleware<T>(wrapped) {
+) : Middleware<Any, T>(wrapped) {
 
     data class Config(
         val locale: Locale = Locale.US,
@@ -23,17 +24,17 @@ class LoggingMiddleware<T : Any>(
         logger("${config.tag}: $message")
     }
 
-    override fun onBind(connection: Connection<T>) {
+    override fun onBind(connection: Connection<Any, T>) {
         super.onBind(connection)
         log(config.onBindTemplate.format(config.locale, connection))
     }
 
-    override fun onElement(connection: Connection<T>, element: T) {
+    override fun onElement(connection: Connection<Any, T>, element: T) {
         super.onElement(connection, element)
         log(config.onElementTemplate.format(config.locale, connection, element))
     }
 
-    override fun onComplete(connection: Connection<T>) {
+    override fun onComplete(connection: Connection<Any, T>) {
         super.onComplete(connection)
         log(config.onCompleteTemplate.format(config.locale, connection))
     }

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
@@ -1,7 +1,6 @@
 package com.badoo.mvicore.consumer.middleware.base
 
 import com.badoo.mvicore.binder.Connection
-import io.reactivex.disposables.Disposable
 import io.reactivex.functions.Consumer
 
 abstract class Middleware<Out, In>(

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
@@ -1,0 +1,42 @@
+package com.badoo.mvicore.consumer.middleware.base
+
+import com.badoo.mvicore.binder.Connection
+import io.reactivex.disposables.Disposable
+import io.reactivex.functions.Consumer
+
+abstract class Middleware<Out, In>(
+    protected val wrapped: Consumer<In>
+): Consumer<In> {
+
+    open fun onBind(connection: Connection<Out, In>) {
+        wrapped.applyIfMiddleware { onBind(connection) }
+    }
+
+    override fun accept(element: In) {
+        wrapped.accept(element)
+    }
+
+    open fun onElement(connection: Connection<Out, In>, element: In) {
+        wrapped.applyIfMiddleware { onElement(connection, element) }
+    }
+
+    open fun onComplete(connection: Connection<Out, In>) {
+        wrapped.applyIfMiddleware { onBind(connection) }
+    }
+
+    private inline fun Consumer<In>.applyIfMiddleware(
+        block: Middleware<Out, In>.() -> Unit
+    ) {
+        if (wrapped is Middleware<*, *>) {
+            (wrapped as Middleware<Out, In>).block()
+        }
+    }
+
+    protected val innerMost by lazy {
+        var consumer = wrapped
+        while (consumer is Middleware<*, *>) {
+            consumer = (consumer as Middleware<Out, In>).wrapped
+        }
+        consumer
+    }
+}

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
@@ -20,7 +20,7 @@ abstract class Middleware<Out, In>(
     }
 
     open fun onComplete(connection: Connection<Out, In>) {
-        wrapped.applyIfMiddleware { onBind(connection) }
+        wrapped.applyIfMiddleware { onComplete(connection) }
     }
 
     private inline fun Consumer<In>.applyIfMiddleware(

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/StandaloneMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/StandaloneMiddleware.kt
@@ -3,15 +3,15 @@ package com.badoo.mvicore.consumer.middleware.base
 import com.badoo.mvicore.binder.Connection
 import io.reactivex.disposables.Disposable
 
-internal class StandaloneMiddleware<Out, In>(
-    private val wrappedMiddleware: Middleware<Out, In>,
+internal class StandaloneMiddleware<In>(
+    private val wrappedMiddleware: Middleware<In, In>,
     name: String? = null,
     postfix: String? = null
-): Middleware<Out, In>(wrappedMiddleware), Disposable {
+): Middleware<In, In>(wrappedMiddleware), Disposable {
 
     private var bound = false
     private var disposed = false
-    private val connection = Connection<Out, In>(
+    private val connection = Connection<In, In>(
         to = innerMost,
         name = "${name ?: innerMost.javaClass.canonicalName}.${postfix ?: "input"}"
     )
@@ -20,7 +20,7 @@ internal class StandaloneMiddleware<Out, In>(
         onBind(connection)
     }
 
-    override fun onBind(connection: Connection<Out, In>) {
+    override fun onBind(connection: Connection<In, In>) {
         assertSame(connection)
 
         bound = true
@@ -32,7 +32,7 @@ internal class StandaloneMiddleware<Out, In>(
         wrappedMiddleware.accept(element)
     }
 
-    override fun onComplete(connection: Connection<Out, In>) {
+    override fun onComplete(connection: Connection<In, In>) {
         wrappedMiddleware.onComplete(connection)
     }
 
@@ -43,7 +43,7 @@ internal class StandaloneMiddleware<Out, In>(
         disposed = true
     }
 
-    private fun assertSame(connection: Connection<Out, In>) {
+    private fun assertSame(connection: Connection<In, In>) {
         if (bound && connection != this.connection) {
             throw IllegalStateException("Middleware was initialised in standalone mode, can't accept other connections")
         }

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/StandaloneMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/StandaloneMiddleware.kt
@@ -39,6 +39,7 @@ internal class StandaloneMiddleware<Out, In>(
     override fun isDisposed() = disposed
 
     override fun dispose() {
+        onComplete(this.connection)
         disposed = true
     }
 

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/StandaloneMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/StandaloneMiddleware.kt
@@ -1,0 +1,51 @@
+package com.badoo.mvicore.consumer.middleware.base
+
+import com.badoo.mvicore.binder.Connection
+import io.reactivex.disposables.Disposable
+
+internal class StandaloneMiddleware<Out, In>(
+    private val wrappedMiddleware: Middleware<Out, In>,
+    name: String? = null,
+    postfix: String? = null
+): Middleware<Out, In>(wrappedMiddleware), Disposable {
+
+    private var bound = false
+    private var disposed = false
+    private val connection = Connection<Out, In>(
+        to = innerMost,
+        name = "${name ?: innerMost.javaClass.canonicalName}.${postfix ?: "input"}"
+    )
+
+    init {
+        onBind(connection)
+    }
+
+    override fun onBind(connection: Connection<Out, In>) {
+        assertSame(connection)
+
+        bound = true
+        wrappedMiddleware.onBind(connection)
+    }
+
+    override fun accept(element: In) {
+        wrappedMiddleware.onElement(connection, element)
+        wrappedMiddleware.accept(element)
+    }
+
+    override fun onComplete(connection: Connection<Out, In>) {
+        wrappedMiddleware.onComplete(connection)
+    }
+
+    override fun isDisposed() = disposed
+
+    override fun dispose() {
+        disposed = true
+    }
+
+    private fun assertSame(connection: Connection<Out, In>) {
+        if (bound && connection != this.connection) {
+            throw IllegalStateException("Middleware was initialised in standalone mode, can't accept other connections")
+        }
+    }
+
+}

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/ConsumerMiddlewareFactory.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/ConsumerMiddlewareFactory.kt
@@ -1,6 +1,6 @@
 package com.badoo.mvicore.consumer.middlewareconfig
 
-import com.badoo.mvicore.consumer.middleware.ConsumerMiddleware
+import com.badoo.mvicore.consumer.middleware.base.Middleware
 import io.reactivex.functions.Consumer
 
-typealias ConsumerMiddlewareFactory<T> = (Consumer<T>) -> ConsumerMiddleware<T>
+typealias ConsumerMiddlewareFactory<T> = (Consumer<T>) -> Middleware<Any, T>

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/MiddlewareConfiguration.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/MiddlewareConfiguration.kt
@@ -1,6 +1,6 @@
 package com.badoo.mvicore.consumer.middlewareconfig
 
-import com.badoo.mvicore.consumer.middleware.ConsumerMiddleware
+import com.badoo.mvicore.consumer.middleware.base.Middleware
 import io.reactivex.functions.Consumer
 
 data class MiddlewareConfiguration(
@@ -17,7 +17,7 @@ data class MiddlewareConfiguration(
         var current = consumerToWrap
         val middlewares = if (condition.shouldWrap(targetToCheck, name, standalone)) factories else listOf()
         middlewares.forEach {
-            current = (it.invoke(current) as ConsumerMiddleware<T>)
+            current = it.invoke(current) as Middleware<Any, T>
         }
 
         return current

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/WrappingCondition.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/WrappingCondition.kt
@@ -1,7 +1,5 @@
 package com.badoo.mvicore.consumer.middlewareconfig
 
-import io.reactivex.functions.Consumer
-
 interface WrappingCondition {
 
     fun shouldWrap(target: Any, name: String?, standalone: Boolean) : Boolean

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
@@ -3,13 +3,8 @@ package com.badoo.mvicore.consumer.playback
 import com.badoo.mvicore.binder.Connection
 import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware
 import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore
-import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.Event
-import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.PlaybackState
-import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.PlaybackState.FINISHED_PLAYBACK
-import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.PlaybackState.IDLE
-import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.PlaybackState.PLAYBACK
-import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.PlaybackState.RECORDING
-import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.RecordKey
+import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.*
+import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.PlaybackState.*
 import com.badoo.mvicore.consumer.util.Logger
 import io.reactivex.Observable
 import io.reactivex.Scheduler

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
@@ -48,19 +48,19 @@ class MemoryRecordStore(
         }
     }
 
-    override fun <T : Any> register(middleware: PlaybackMiddleware<T>, endpoints: Connection<T>) {
+    override fun <T : Any> register(middleware: PlaybackMiddleware<T>, endpoints: Connection<Any, T>) {
         cachedEvents[Key(middleware, endpoints)] = mutableListOf()
         updateRecords()
     }
 
-    override fun <T : Any> unregister(middleware: PlaybackMiddleware<T>, endpoints: Connection<T>) {
+    override fun <T : Any> unregister(middleware: PlaybackMiddleware<T>, endpoints: Connection<Any, T>) {
         val key = Key(middleware, endpoints)
         cachedEvents.remove(key)
         lastElementBuffer.remove(key)
         updateRecords()
     }
 
-    override fun <T : Any> record(middleware: PlaybackMiddleware<T>, endpoints: Connection<T>, element: T) {
+    override fun <T : Any> record(middleware: PlaybackMiddleware<T>, endpoints: Connection<Any, T>, element: T) {
         val key = Key(middleware, endpoints)
         lastElementBuffer[key] = element
 
@@ -132,7 +132,7 @@ class MemoryRecordStore(
 
     private data class Key<T : Any>(
         val middleWare: PlaybackMiddleware<T>,
-        val connection: Connection<T>
+        val connection: Connection<Any, T>
     ) {
         val id = hashCode()
 

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
@@ -17,8 +17,8 @@ class MemoryRecordStore(
 ) : RecordStore {
     private val state: BehaviorSubject<PlaybackState> = BehaviorSubject.createDefault(IDLE)
     private val records: BehaviorSubject<List<RecordKey>> = BehaviorSubject.createDefault(emptyList())
-    private val cachedEvents: MutableMap<Key<*>, MutableList<Event>> = mutableMapOf()
-    private val lastElementBuffer: MutableMap<Key<*>, Any> = mutableMapOf()
+    private val cachedEvents: MutableMap<Key<*, *>, MutableList<Event>> = mutableMapOf()
+    private val lastElementBuffer: MutableMap<Key<*, *>, Any> = mutableMapOf()
     private var isRecording = false
     private var recordBaseTimestampNanos = 0L
 
@@ -43,19 +43,19 @@ class MemoryRecordStore(
         }
     }
 
-    override fun <T : Any> register(middleware: PlaybackMiddleware<T>, endpoints: Connection<Any, T>) {
+    override fun <Out: Any, In: Any> register(middleware: PlaybackMiddleware<Out, In>, endpoints: Connection<Out, In>) {
         cachedEvents[Key(middleware, endpoints)] = mutableListOf()
         updateRecords()
     }
 
-    override fun <T : Any> unregister(middleware: PlaybackMiddleware<T>, endpoints: Connection<Any, T>) {
+    override fun <Out: Any, In: Any> unregister(middleware: PlaybackMiddleware<Out, In>, endpoints: Connection<Out, In>) {
         val key = Key(middleware, endpoints)
         cachedEvents.remove(key)
         lastElementBuffer.remove(key)
         updateRecords()
     }
 
-    override fun <T : Any> record(middleware: PlaybackMiddleware<T>, endpoints: Connection<Any, T>, element: T) {
+    override fun <Out: Any, In: Any> record(middleware: PlaybackMiddleware<Out, In>, endpoints: Connection<Out, In>, element: In) {
         val key = Key(middleware, endpoints)
         lastElementBuffer[key] = element
 
@@ -125,9 +125,9 @@ class MemoryRecordStore(
             }
     }
 
-    private data class Key<T : Any>(
-        val middleWare: PlaybackMiddleware<T>,
-        val connection: Connection<Any, T>
+    private data class Key<Out: Any, In: Any>(
+        val middleWare: PlaybackMiddleware<Out, In>,
+        val connection: Connection<Out, In>
     ) {
         val id = hashCode()
 

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
@@ -1,15 +1,10 @@
 package com.badoo.mvicore.feature
 
 import com.badoo.mvicore.consumer.wrapWithMiddleware
-import com.badoo.mvicore.element.Actor
-import com.badoo.mvicore.element.Bootstrapper
-import com.badoo.mvicore.element.NewsPublisher
-import com.badoo.mvicore.element.PostProcessor
-import com.badoo.mvicore.element.Reducer
-import com.badoo.mvicore.element.WishToAction
+import com.badoo.mvicore.element.*
+import com.badoo.mvicore.extension.SameThreadVerifier
 import com.badoo.mvicore.extension.asConsumer
 import com.badoo.mvicore.feature.internal.DisposableCollection
-import com.badoo.mvicore.extension.SameThreadVerifier
 import io.reactivex.ObservableSource
 import io.reactivex.Observer
 import io.reactivex.functions.Consumer

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
@@ -27,15 +27,19 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
     private val stateSubject = BehaviorSubject.createDefault(initialState)
     private val newsSubject = PublishSubject.create<News>()
     private val disposables = DisposableCollection()
-    private val postProcessorWrapper = postProcessor?.let { PostProcessorWrapper(
-        postProcessor,
-        actionSubject
-    ).wrapWithMiddleware(wrapperOf = postProcessor)}
+    private val postProcessorWrapper = postProcessor?.let {
+        PostProcessorWrapper(
+            postProcessor,
+            actionSubject
+        ).wrapWithMiddleware(wrapperOf = postProcessor)
+    }
 
-    private val newsPublisherWrapper = newsPublisher?.let { NewsPublisherWrapper(
-        newsPublisher,
-        newsSubject
-    ).wrapWithMiddleware(wrapperOf = newsPublisher)}
+    private val newsPublisherWrapper = newsPublisher?.let {
+        NewsPublisherWrapper(
+            newsPublisher,
+            newsSubject
+        ).wrapWithMiddleware(wrapperOf = newsPublisher)
+    }
 
     private val reducerWrapper = ReducerWrapper(
         reducer,
@@ -62,15 +66,16 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
         }
 
         bootstrapper?.let {
-            actionSubject.asConsumer().wrapWithMiddleware(
-                wrapperOf = it,
-                postfix = "output"
-            ).also { output ->
-                disposables += output
-                disposables += bootstrapper.invoke().subscribe {
-                    output.accept(it)
+            actionSubject.asConsumer()
+                .wrapWithMiddleware(
+                    wrapperOf = it,
+                    postfix = "output"
+                ).also { output ->
+                    disposables += output
+                    disposables += bootstrapper.invoke().subscribe {
+                        output.accept(it)
+                    }
                 }
-            }
         }
     }
 

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
@@ -1,6 +1,6 @@
 package com.badoo.mvicore.feature
 
-import com.badoo.mvicore.consumer.wrap
+import com.badoo.mvicore.consumer.wrapWithMiddleware
 import com.badoo.mvicore.element.Actor
 import com.badoo.mvicore.element.Bootstrapper
 import com.badoo.mvicore.element.NewsPublisher
@@ -35,19 +35,19 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
     private val postProcessorWrapper = postProcessor?.let { PostProcessorWrapper(
         postProcessor,
         actionSubject
-    ).wrap(wrapperOf = postProcessor)}
+    ).wrapWithMiddleware(wrapperOf = postProcessor)}
 
     private val newsPublisherWrapper = newsPublisher?.let { NewsPublisherWrapper(
         newsPublisher,
         newsSubject
-    ).wrap(wrapperOf = newsPublisher)}
+    ).wrapWithMiddleware(wrapperOf = newsPublisher)}
 
     private val reducerWrapper = ReducerWrapper(
         reducer,
         stateSubject,
         postProcessorWrapper,
         newsPublisherWrapper
-    ).wrap(wrapperOf = reducer)
+    ).wrapWithMiddleware(wrapperOf = reducer)
 
     private val actorWrapper = ActorWrapper(
         threadVerifier,
@@ -55,7 +55,7 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
         actor,
         stateSubject,
         reducerWrapper
-    ).wrap(wrapperOf = actor)
+    ).wrapWithMiddleware(wrapperOf = actor)
 
     init {
         disposables += actorWrapper
@@ -67,7 +67,7 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
         }
 
         bootstrapper?.let {
-            actionSubject.asConsumer().wrap(
+            actionSubject.asConsumer().wrapWithMiddleware(
                 wrapperOf = it,
                 postfix = "output"
             ).also { output ->

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
@@ -1,7 +1,12 @@
 package com.badoo.mvicore.feature
 
 import com.badoo.mvicore.consumer.wrapWithMiddleware
-import com.badoo.mvicore.element.*
+import com.badoo.mvicore.element.Actor
+import com.badoo.mvicore.element.Bootstrapper
+import com.badoo.mvicore.element.NewsPublisher
+import com.badoo.mvicore.element.PostProcessor
+import com.badoo.mvicore.element.Reducer
+import com.badoo.mvicore.element.WishToAction
 import com.badoo.mvicore.extension.SameThreadVerifier
 import com.badoo.mvicore.extension.asConsumer
 import com.badoo.mvicore.feature.internal.DisposableCollection


### PR DESCRIPTION
The `Connection` class we have right now is somehow limited for external observer (any middleware).
If you apply transformer, the only source the middleware will receive is `ObservableFlatMap` which is far from ideal.
This pull request tries to fix this issue, updating type signature to `Connection<Out, In>`, adding parameters for source and transformer and updating built-in middlewares to work with current implementation.
This PR does break backward compatibility for `Connection` usages, but I could not find any in our codebase, so I conclude it is not explicitly broadly used.