### PR TITLE
Add named params to typealias elements

### DIFF
--- a/mvicore/src/main/java/com/badoo/mvicore/element/Actor.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/Actor.kt
@@ -2,4 +2,5 @@ package com.badoo.mvicore.element
 
 import io.reactivex.Observable
 
-typealias Actor<State, Action, Effect> = (State, Action) -> Observable<out Effect>
+typealias Actor<State, Action, Effect> =
+    (state: State, action: Action) -> Observable<out Effect>

--- a/mvicore/src/main/java/com/badoo/mvicore/element/NewsPublisher.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/NewsPublisher.kt
@@ -1,3 +1,4 @@
 package com.badoo.mvicore.element
 
-typealias NewsPublisher<Action, Effect, State, News> = (Action, Effect, State) -> News?
+typealias NewsPublisher<Action, Effect, State, News> =
+    (action: Action, effect: Effect, state: State) -> News?

--- a/mvicore/src/main/java/com/badoo/mvicore/element/PostProcessor.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/PostProcessor.kt
@@ -1,3 +1,5 @@
 package com.badoo.mvicore.element
 
-typealias PostProcessor<Action, Effect, State> = (Action, Effect, State) -> Action?
+typealias PostProcessor<Action, Effect, State> =
+    (action: Action, effect: Effect, state: State) -> Action?
+

--- a/mvicore/src/main/java/com/badoo/mvicore/element/Reducer.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/Reducer.kt
@@ -1,3 +1,4 @@
 package com.badoo.mvicore.element
 
-typealias Reducer<State, Effect> = (State, Effect) -> State
+typealias Reducer<State, Effect> =
+    (state: State, effect: Effect) -> State

--- a/mvicore/src/main/java/com/badoo/mvicore/element/WishToAction.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/WishToAction.kt
@@ -1,3 +1,3 @@
 package com.badoo.mvicore.element
 
-typealias WishToAction<Wish, Action> = (Wish) -> Action
+typealias WishToAction<Wish, Action> = (wish: Wish) -> Action


### PR DESCRIPTION
If you extend these interfaces, and use AS to generate default implementation it will generate something like:
```
override fun invoke(p1: Action, p2: State): Observable<Effect>
```

This PR improves readability of this a tiny bit, producing:
```
override fun invoke(action: Action, state: State): Observable<Effect>
```