### PR TITLE
Add syntactic sugar for watchers

### DIFF
--- a/documentation/extras/modelwatcher.md
+++ b/documentation/extras/modelwatcher.md
@@ -1,6 +1,6 @@
 ## Efficient view updates
 
-MVICore includes utility classes to observe difference in the received models and prevent redundant view updates.
+MVICore includes utility class to observe difference in the received models and prevent redundant view updates.
 
 ```kotlin
 data class ViewModel(
@@ -44,16 +44,44 @@ The difference can be observed on more than one field with custom diff strategy.
 For example, if the click listener should not be set when something is loading, you can do the following:
 ```kotlin
 // Check whether either loading flag or action changed
-fun byLoadingAndAction() = { p1, p2 ->
+val byLoadingAndAction: DiffStrategy<Model> = { p1, p2 ->
     p1.isLoading != p2.isLoading || p1.buttonAction !== p2.buttonAction
 }
 
 val watcher = modelWatcher {
-    watch({ it }, diffStrategy = byLoadingAndAction()) { model ->
+    watch({ it }, diffStrategy = byLoadingAndAction) { model ->
         // Allow action only when not loading
         button.setOnClickListener(
             if (!model.isLoading) model.buttonAction else null
         )
+    }
+}
+```
+
+The watcher also provides an optional DSL to add more clarity to the definitions:
+```kotlin
+val watcher = modelWatcher {
+    // Method call
+    watch(ViewModel::buttonText) {
+        button.text = it
+    }
+    
+    // DSL
+    ViewModel::buttonText {
+       button.text = it
+    }
+}
+```
+The same applies to custom strategies.
+```kotlin
+val watcher = modelWatcher {
+    // Method call
+    watch(Model::buttonAction, diffStrategy = byRef()) { }
+    
+    // DSL
+    val byRef = byRef<() -> Unit>()
+    Model::buttonAction using byRef {
+    
     }
 }
 ```

--- a/mvicore-diff/build.gradle
+++ b/mvicore-diff/build.gradle
@@ -53,11 +53,11 @@ artifacts {
 }
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "1.6"
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "1.6"
     }
 }

--- a/mvicore-diff/src/main/java/com/badoo/mvicore/ModelWatcher.kt
+++ b/mvicore-diff/src/main/java/com/badoo/mvicore/ModelWatcher.kt
@@ -39,12 +39,26 @@ class ModelWatcher<T> private constructor(
             ) as Watcher<T, Any?>
         }
 
+        /*
+         * Syntactic sugar around watch (scoped inside the builder)
+         */
+
+        operator fun <R> ((T) -> R).invoke(callback: (R) -> Unit) {
+            watch(this, callback = callback)
+        }
+
+        infix fun <R> ((T) -> R).using(pair: Pair<DiffStrategy<R>, (R) -> Unit>) {
+            watch(this, pair.first, pair.second)
+        }
+
+        operator fun <R> (DiffStrategy<R>).invoke(callback: (R) -> Unit) =
+            this to callback
+
         @PublishedApi
         internal fun build(): ModelWatcher<T> =
             ModelWatcher(watchers)
     }
 }
-
 
 inline fun <T> modelWatcher(init: ModelWatcher.Builder<T>.() -> Unit): ModelWatcher<T> =
     ModelWatcher.Builder<T>()

--- a/mvicore-diff/src/test/java/com/badoo/mvicore/ModelWatcherTest.kt
+++ b/mvicore-diff/src/test/java/com/badoo/mvicore/ModelWatcherTest.kt
@@ -69,4 +69,36 @@ class ModelWatcherTest {
 
         assertEquals(1, results.size)
     }
+
+    @Test
+    fun `invokes callback using dsl`() {
+        val results = testWatcher<Int>(
+            listOf(
+                Model(int = 0), Model(int = 1)
+            )
+        ) { updates ->
+            Model::int {
+                updates += it
+            }
+        }
+
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun `invokes callback using dsl with diffStrategy`() {
+        val results = testWatcher<List<String>>(
+            listOf(
+                Model(list = listOf("")),
+                Model(list = listOf(""))
+            )
+        ) { updates ->
+            val byRef = byRef<List<String>>()
+            Model::list using byRef {
+                updates += it
+            }
+        }
+
+        assertEquals(2, results.size)
+    }
 }


### PR DESCRIPTION
Add some dsl inside the ModelWatcher.Builder, allowing for syntax like:
```kotlin
val watcher = modelWatcher {
    ViewModel::buttonText {
       button.text = it
    }
}
```