### PR TITLE
Allow covariant endpoints

### DIFF
--- a/documentation/binder/binder-advanced.md
+++ b/documentation/binder/binder-advanced.md
@@ -20,7 +20,7 @@ However, sometimes this is not enough.
 For more complex cases, we can use a `Connector<A, B>` instead, which is also able to manipulate the stream.
 ```kotlin
 object OutputToInput : Connector<A, B> {
-    override fun invoke(source: ObservableSource<A>): ObservableSource<B> =
+    override fun invoke(source: ObservableSource<out A>): ObservableSource<B> =
         Observable.wrap(source)
             // TODO transform stream
             .map { a -> TODO() }

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
@@ -31,7 +31,7 @@ class Binder(
 
     // region bind
 
-    fun <T: Any> bind(connection: Pair<ObservableSource<T>, Consumer<T>>) {
+    fun <T: Any> bind(connection: Pair<ObservableSource<out T>, Consumer<in T>>) {
         bind(
             Connection(
                 from = connection.first,

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Binder.kt
@@ -59,7 +59,7 @@ class Binder(
         }
     }
 
-    private fun <Out: Any, In: Any> subscribeWithLifecycle(
+    private fun <Out, In> subscribeWithLifecycle(
         connection: Connection<Out, In>,
         middleware: Middleware<Out, In>?
     ) {
@@ -67,7 +67,7 @@ class Binder(
             .subscribeWithMiddleware(connection, middleware)
     }
 
-    private fun <Out: Any, In: Any> subscribe(
+    private fun <Out, In> subscribe(
         connection: Connection<Out, In>,
         middleware: Middleware<Out, In>?
     ) {
@@ -75,7 +75,7 @@ class Binder(
             .subscribeWithMiddleware(connection, middleware)
     }
 
-    private fun <Out: Any, In: Any> Observable<Out>.subscribeWithMiddleware(
+    private fun <Out, In> Observable<out Out>.subscribeWithMiddleware(
         connection: Connection<Out, In>,
         middleware: Middleware<Out, In>?
     ): Disposable =
@@ -94,7 +94,7 @@ class Binder(
                 }
             }
 
-    private fun <Out: Any, In: Any> Observable<Out>.applyTransformer(
+    private fun <Out, In> Observable<out Out>.applyTransformer(
         connection: Connection<Out, In>
     ): Observable<In> =
         connection.connector?.let {

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
@@ -6,8 +6,8 @@ import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 
 data class Connection<Out, In>(
-    val from: ObservableSource<Out>? = null,
-    val to: Consumer<In>,
+    val from: ObservableSource<out Out>? = null,
+    val to: Consumer<in In>,
     val connector: Connector<Out, In>? = null,
     val name: String? = null
 ) {

--- a/mvicore/src/main/java/com/badoo/mvicore/connector/Connector.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/connector/Connector.kt
@@ -2,4 +2,4 @@ package com.badoo.mvicore.connector
 
 import io.reactivex.ObservableSource
 
-interface Connector<Out, In>: (ObservableSource<Out>) -> ObservableSource<In>
+interface Connector<Out, In>: (ObservableSource<out Out>) -> ObservableSource<In>

--- a/mvicore/src/main/java/com/badoo/mvicore/connector/NotNullConnector.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/connector/NotNullConnector.kt
@@ -5,7 +5,7 @@ import io.reactivex.Observable.wrap
 import io.reactivex.ObservableSource
 
 internal class NotNullConnector<Out, In>(private val mapper: (Out) -> In?): Connector<Out, In> {
-    override fun invoke(element: ObservableSource<Out>): ObservableSource<In> =
+    override fun invoke(element: ObservableSource<out Out>): ObservableSource<In> =
         wrap(element)
             .flatMap {
                 mapper(it)

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/Consumer.kt
@@ -19,7 +19,7 @@ import io.reactivex.functions.Consumer
  * @param postfix       Passed on to [ConsumerMiddleware], in most cases you shouldn't need to override this.
  * @param wrapperOf     Passed on to [ConsumerMiddleware], in most cases you shouldn't need to override this.
  */
-fun <In : Any> Consumer<In>.wrapWithMiddleware(
+fun <In> Consumer<In>.wrapWithMiddleware(
     standalone: Boolean = true,
     name: String? = null,
     postfix: String? = null,

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/base/Middleware.kt
@@ -26,8 +26,8 @@ abstract class Middleware<Out, In>(
     private inline fun Consumer<In>.applyIfMiddleware(
         block: Middleware<Out, In>.() -> Unit
     ) {
-        if (wrapped is Middleware<*, *>) {
-            (wrapped as Middleware<Out, In>).block()
+        if (this is Middleware<*, *>) {
+            (this as Middleware<Out, In>).block()
         }
     }
 

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/MiddlewareConfiguration.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middlewareconfig/MiddlewareConfiguration.kt
@@ -8,7 +8,7 @@ data class MiddlewareConfiguration(
     private val factories: List<ConsumerMiddlewareFactory<*>>
 ) {
 
-    fun <T : Any> applyOn(
+    fun <T> applyOn(
         consumerToWrap: Consumer<T>,
         targetToCheck: Any,
         name: String?,

--- a/mvicore/src/test/java/com/badoo/mvicore/binder/BinderTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/binder/BinderTest.kt
@@ -31,12 +31,24 @@ class BinderTest {
         consumer.assertValues("0", "1")
     }
 
+    @Test
+    fun `covariant endpoints compile for pair`() {
+        val anyConsumer = TestConsumer<Any>()
+        binder.bind(source to anyConsumer)
+    }
+
+    @Test
+    fun `covariant endpoints compile for connection dsl`() {
+        val anyConsumer = TestConsumer<Any>()
+        binder.bind(source to anyConsumer using IntToString)
+    }
+
     object IntToString: (Int) -> String {
         override fun invoke(it: Int): String = it.toString()
     }
 
     object TestConnector: Connector<Int, String> {
-        override fun invoke(it: ObservableSource<Int>): ObservableSource<String> =
+        override fun invoke(it: ObservableSource<out Int>): ObservableSource<String> =
             wrap(it).flatMap {
                 just(it.toString(), (it + 1).toString())
             }


### PR DESCRIPTION
We used to allow covariance between endpoint and source before connection update.
This PR returns that, effectively allowing you to use more generic type on the consumer.
```
private val source: Observable<Int>
private val consumer: Consumer<Any>

binder.bind(source to consumer) // Now compiles
```