### PR TITLE
Fix variance for types in dsl methods

### DIFF
--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
@@ -32,7 +32,7 @@ infix fun <Out, In> Pair<ObservableSource<out Out>, Consumer<in In>>.using(conne
         connector = connector
     )
 
-infix fun <T> Pair<ObservableSource<T>, Consumer<T>>.named(name: String): Connection<T, T> =
+infix fun <T> Pair<ObservableSource<out T>, Consumer<in T>>.named(name: String): Connection<T, T> =
     Connection(
         from = first,
         to = second,

--- a/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/binder/Connection.kt
@@ -22,10 +22,10 @@ data class Connection<Out, In>(
         "<${name ?: ANONYMOUS}> (${from ?: "?"} --> $to${connector?.let { " using $it" } ?: ""})"
 }
 
-infix fun <Out, In> Pair<ObservableSource<Out>, Consumer<In>>.using(transformer: (Out) -> In?): Connection<Out, In> =
+infix fun <Out, In> Pair<ObservableSource<out Out>, Consumer<in In>>.using(transformer: (Out) -> In?): Connection<Out, In> =
     using(NotNullConnector(transformer))
 
-infix fun <Out, In> Pair<ObservableSource<Out>, Consumer<In>>.using(connector: Connector<Out, In>): Connection<Out, In> =
+infix fun <Out, In> Pair<ObservableSource<out Out>, Consumer<in In>>.using(connector: Connector<Out, In>): Connection<Out, In> =
     Connection(
         from = first,
         to = second,

--- a/mvicore/src/test/java/com/badoo/mvicore/binder/BinderTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/binder/BinderTest.kt
@@ -39,7 +39,7 @@ class BinderTest {
 
     @Test
     fun `covariant endpoints compile for connection dsl`() {
-        val anyConsumer = TestConsumer<Any>()
+        val anyConsumer = TestConsumer<Any?>()
         binder.bind(source to anyConsumer using IntToString)
     }
 


### PR DESCRIPTION
While doing #86, I forgot about types in our dsl methods, so here they are fixed as well.