### PR TITLE
Fix 1.2.0 debug drawer build

### DIFF
--- a/mvicore-debugdrawer/build.gradle
+++ b/mvicore-debugdrawer/build.gradle
@@ -33,8 +33,8 @@ dependencies {
 
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
 
+    implementation deps('io.palaima.debugdrawer:debugdrawer-base')
     debugImplementation deps('io.palaima.debugdrawer:debugdrawer')
-    debugImplementation deps('io.palaima.debugdrawer:debugdrawer-base')
     debugImplementation deps('io.palaima.debugdrawer:debugdrawer-view')
     releaseImplementation deps('io.palaima.debugdrawer:debugdrawer-no-op')
     releaseImplementation deps('io.palaima.debugdrawer:debugdrawer-view-no-op')


### PR DESCRIPTION
Seems like I have accidentally added the debug drawer base artifact for debug only. ¯\\_(ツ)_/¯