### PR TITLE
Fix broken link in logging middleware documentation

### DIFF
--- a/documentation/middlewares/loggingmiddleware.md
+++ b/documentation/middlewares/loggingmiddleware.md
@@ -10,4 +10,4 @@ val wrapped = LoggingMiddleware(consumer, { System.out.println(it) })
 
 The actual logging part is not hardcoded, so you can set your preferred way of producing output.
 
-The constructor also accepts an optional `Configuration` object if you want to modify the templates it uses. Check the [actual file](https://github.com/badoo/MVICore/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt) for more details.
+The constructor also accepts an optional `Configuration` object if you want to modify the templates it uses. Check the [actual file](https://github.com/badoo/MVICore/blob/master/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt) for more details.


### PR DESCRIPTION
[LoggingMiddleware file link](https://github.com/badoo/MVICore/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt) from the [documentation](https://badoo.github.io/MVICore/middlewares/loggingmiddleware/) was leading nowhere.

Replace it with [a working link](https://github.com/badoo/MVICore/blob/master/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt).