### PR TITLE
Migrate to rxjava3

### DIFF
--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -21,8 +21,8 @@ repositories {
 dependencies {
     def deps = rootProject.ext.deps
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxkotlin')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxkotlin')
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
 
     testImplementation deps('junit:junit')

--- a/binder/src/main/java/com/badoo/binder/Binder.kt
+++ b/binder/src/main/java/com/badoo/binder/Binder.kt
@@ -5,13 +5,13 @@ import com.badoo.binder.lifecycle.Lifecycle.Event.BEGIN
 import com.badoo.binder.lifecycle.Lifecycle.Event.END
 import com.badoo.binder.middleware.base.Middleware
 import com.badoo.binder.middleware.wrapWithMiddleware
-import io.reactivex.Observable
-import io.reactivex.Observable.wrap
-import io.reactivex.ObservableSource
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Consumer
-import io.reactivex.rxkotlin.plusAssign
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Observable.wrap
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.functions.Consumer
+import io.reactivex.rxjava3.kotlin.plusAssign
 
 class Binder(
     private val lifecycle: Lifecycle? = null
@@ -143,3 +143,4 @@ class Binder(
         disposables.clear()
     }
 }
+

--- a/binder/src/main/java/com/badoo/binder/Connection.kt
+++ b/binder/src/main/java/com/badoo/binder/Connection.kt
@@ -2,14 +2,14 @@ package com.badoo.binder
 
 import com.badoo.binder.connector.Connector
 import com.badoo.binder.connector.NotNullConnector
-import io.reactivex.ObservableSource
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.Consumer
 
 data class Connection<Out, In>(
-    val from: ObservableSource<out Out>? = null,
-    val to: Consumer<in In>,
-    val connector: Connector<Out, In>? = null,
-    val name: String? = null
+        val from: ObservableSource<out Out>? = null,
+        val to: Consumer<in In>,
+        val connector: Connector<Out, In>? = null,
+        val name: String? = null
 ) {
     companion object {
         private const val ANONYMOUS: String = "anonymous"

--- a/binder/src/main/java/com/badoo/binder/connector/Connector.kt
+++ b/binder/src/main/java/com/badoo/binder/connector/Connector.kt
@@ -1,5 +1,5 @@
 package com.badoo.binder.connector
 
-import io.reactivex.ObservableSource
+import io.reactivex.rxjava3.core.ObservableSource
 
 interface Connector<Out, In>: (ObservableSource<out Out>) -> ObservableSource<In>

--- a/binder/src/main/java/com/badoo/binder/connector/NotNullConnector.kt
+++ b/binder/src/main/java/com/badoo/binder/connector/NotNullConnector.kt
@@ -1,8 +1,8 @@
 package com.badoo.binder.connector
 
-import io.reactivex.Observable
-import io.reactivex.Observable.wrap
-import io.reactivex.ObservableSource
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Observable.wrap
+import io.reactivex.rxjava3.core.ObservableSource
 
 internal class NotNullConnector<Out, In>(private val mapper: (Out) -> In?): Connector<Out, In> {
     override fun invoke(element: ObservableSource<out Out>): ObservableSource<In> =

--- a/binder/src/main/java/com/badoo/binder/lifecycle/Lifecycle.kt
+++ b/binder/src/main/java/com/badoo/binder/lifecycle/Lifecycle.kt
@@ -1,7 +1,7 @@
 package com.badoo.binder.lifecycle
 
 import com.badoo.binder.lifecycle.internal.FromObservableSource
-import io.reactivex.ObservableSource
+import io.reactivex.rxjava3.core.ObservableSource
 
 interface Lifecycle : ObservableSource<Lifecycle.Event> {
 

--- a/binder/src/main/java/com/badoo/binder/lifecycle/ManualLifecycle.kt
+++ b/binder/src/main/java/com/badoo/binder/lifecycle/ManualLifecycle.kt
@@ -3,7 +3,7 @@ package com.badoo.binder.lifecycle
 import com.badoo.binder.lifecycle.Lifecycle.Event
 import com.badoo.binder.lifecycle.Lifecycle.Event.BEGIN
 import com.badoo.binder.lifecycle.Lifecycle.Event.END
-import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.rxjava3.subjects.BehaviorSubject
 
 class ManualLifecycle(private val subject : BehaviorSubject<Event> = BehaviorSubject.create()) : Lifecycle by Lifecycle.wrap(subject) {
 

--- a/binder/src/main/java/com/badoo/binder/lifecycle/internal/FromObservableSource.kt
+++ b/binder/src/main/java/com/badoo/binder/lifecycle/internal/FromObservableSource.kt
@@ -1,7 +1,7 @@
 package com.badoo.binder.lifecycle.internal
 
 import com.badoo.binder.lifecycle.Lifecycle
-import io.reactivex.ObservableSource
+import io.reactivex.rxjava3.core.ObservableSource
 
 internal class FromObservableSource(
     source: ObservableSource<Lifecycle.Event>

--- a/binder/src/main/java/com/badoo/binder/middleware/Consumer.kt
+++ b/binder/src/main/java/com/badoo/binder/middleware/Consumer.kt
@@ -4,7 +4,7 @@ import com.badoo.binder.middleware.base.Middleware
 import com.badoo.binder.middleware.base.StandaloneMiddleware
 import com.badoo.binder.middleware.config.Middlewares
 import com.badoo.binder.middleware.config.NonWrappable
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 /**
  * Wraps a Consumer<T> with Middlewares. The list of Middlewares that will be applied is resolved

--- a/binder/src/main/java/com/badoo/binder/middleware/base/Middleware.kt
+++ b/binder/src/main/java/com/badoo/binder/middleware/base/Middleware.kt
@@ -1,7 +1,7 @@
 package com.badoo.binder.middleware.base
 
 import com.badoo.binder.Connection
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 abstract class Middleware<Out, In>(
     protected val wrapped: Consumer<In>

--- a/binder/src/main/java/com/badoo/binder/middleware/base/StandaloneMiddleware.kt
+++ b/binder/src/main/java/com/badoo/binder/middleware/base/StandaloneMiddleware.kt
@@ -1,7 +1,7 @@
 package com.badoo.binder.middleware.base
 
 import com.badoo.binder.Connection
-import io.reactivex.disposables.Disposable
+import io.reactivex.rxjava3.disposables.Disposable
 
 internal class StandaloneMiddleware<In>(
     private val wrappedMiddleware: Middleware<In, In>,

--- a/binder/src/main/java/com/badoo/binder/middleware/config/ConsumerMiddlewareFactory.kt
+++ b/binder/src/main/java/com/badoo/binder/middleware/config/ConsumerMiddlewareFactory.kt
@@ -1,6 +1,6 @@
 package com.badoo.binder.middleware.config
 
 import com.badoo.binder.middleware.base.Middleware
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 typealias ConsumerMiddlewareFactory<T> = (Consumer<T>) -> Middleware<Any, T>

--- a/binder/src/main/java/com/badoo/binder/middleware/config/MiddlewareConfiguration.kt
+++ b/binder/src/main/java/com/badoo/binder/middleware/config/MiddlewareConfiguration.kt
@@ -1,7 +1,7 @@
 package com.badoo.binder.middleware.config
 
 import com.badoo.binder.middleware.base.Middleware
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 data class MiddlewareConfiguration(
     private val condition: WrappingCondition,
@@ -9,10 +9,10 @@ data class MiddlewareConfiguration(
 ) {
 
     fun <T> applyOn(
-        consumerToWrap: Consumer<T>,
-        targetToCheck: Any,
-        name: String?,
-        standalone: Boolean
+            consumerToWrap: Consumer<T>,
+            targetToCheck: Any,
+            name: String?,
+            standalone: Boolean
     ): Consumer<T> {
         var current = consumerToWrap
         val middlewares = if (condition.shouldWrap(targetToCheck, name, standalone)) factories else listOf()

--- a/binder/src/test/java/com/badoo/binder/BinderTest.kt
+++ b/binder/src/test/java/com/badoo/binder/BinderTest.kt
@@ -1,9 +1,9 @@
 package com.badoo.binder
 
 import com.badoo.binder.connector.Connector
-import io.reactivex.Observable
-import io.reactivex.ObservableSource
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.subjects.PublishSubject
 import org.junit.Test
 
 class BinderTest {

--- a/binder/src/test/java/com/badoo/binder/LifecycleTest.kt
+++ b/binder/src/test/java/com/badoo/binder/LifecycleTest.kt
@@ -6,9 +6,9 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-import io.reactivex.ObservableSource
-import io.reactivex.functions.Consumer
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.Consumer
+import io.reactivex.rxjava3.subjects.PublishSubject
 import org.junit.Test
 
 

--- a/binder/src/test/java/com/badoo/binder/TestConsumer.kt
+++ b/binder/src/test/java/com/badoo/binder/TestConsumer.kt
@@ -1,6 +1,6 @@
 package com.badoo.binder
 
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 import kotlin.test.assertEquals
 
 class TestConsumer<T> : Consumer<T> {

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ ext {
     constraintLayoutVersion = '1.1.2'
 
     // Rx
-    rxJavaVersion = '2.2.10'
-    rxKotlinVersion = '2.2.0'
-    rxAndroidVersion = '2.1.1'
+    rxJavaVersion = '3.0.6'
+    rxKotlinVersion = '3.0.1'
+    rxAndroidVersion = '3.0.0'
 
     // DI
     daggerVersion = '2.14.1'
@@ -39,7 +39,8 @@ ext {
 
     // Network
     okhttpVersion = '3.10.0'
-    retrofitVersion = '2.4.0'
+    retrofitVersion = '2.9.0'
+    retrofitAdapterVersion = '3.0.0'
     gsonVersion = '2.8.5'
 
     // Testing
@@ -59,9 +60,9 @@ ext {
             "com.android.support:design"                        : androidSupportLibVersion,
 
             // Rx
-            "io.reactivex.rxjava2:rxjava"                       : rxJavaVersion,
-            "io.reactivex.rxjava2:rxkotlin"                     : rxKotlinVersion,
-            "io.reactivex.rxjava2:rxandroid"                    : rxAndroidVersion,
+            "io.reactivex.rxjava3:rxjava"                       : rxJavaVersion,
+            "io.reactivex.rxjava3:rxkotlin"                     : rxKotlinVersion,
+            "io.reactivex.rxjava3:rxandroid"                    : rxAndroidVersion,
 
             // DI
             "com.google.dagger:dagger"                          : daggerVersion,
@@ -91,8 +92,8 @@ ext {
             // Network
             "com.squareup.okhttp3:okhttp"                       : okhttpVersion,
             "com.squareup.retrofit2:retrofit"                   : retrofitVersion,
-            "com.squareup.retrofit2:adapter-rxjava2"            : retrofitVersion,
             "com.squareup.retrofit2:converter-simplexml"        : retrofitVersion,
+            "com.github.akarnokd:rxjava3-retrofit-adapter"      : retrofitAdapterVersion,
             "com.google.code.gson:gson"                         : gsonVersion,
 
             // Testing

--- a/mvicore-android/build.gradle
+++ b/mvicore-android/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     implementation deps('android.arch.lifecycle:common-java8')
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxkotlin')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxkotlin')
 
     testImplementation deps('junit:junit')
     testImplementation deps('org.jetbrains.kotlin:kotlin-test-junit')

--- a/mvicore-android/src/main/java/com/badoo/mvicore/android/lifecycle/BaseAndroidBinderLifecycle.kt
+++ b/mvicore-android/src/main/java/com/badoo/mvicore/android/lifecycle/BaseAndroidBinderLifecycle.kt
@@ -2,8 +2,8 @@ package com.badoo.mvicore.android.lifecycle
 
 import android.arch.lifecycle.DefaultLifecycleObserver
 import android.arch.lifecycle.LifecycleObserver
-import io.reactivex.ObservableSource
-import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.subjects.BehaviorSubject
 import android.arch.lifecycle.Lifecycle as AndroidLifecycle
 import com.badoo.binder.lifecycle.Lifecycle as BinderLifecycle
 

--- a/mvicore-debugdrawer/build.gradle
+++ b/mvicore-debugdrawer/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 
     implementation deps('com.android.support.constraint:constraint-layout')
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxkotlin')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxkotlin')
 
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
 

--- a/mvicore-debugdrawer/src/main/java/com/badoo/mvicore/debugdrawer/MviCoreControlsModule.kt
+++ b/mvicore-debugdrawer/src/main/java/com/badoo/mvicore/debugdrawer/MviCoreControlsModule.kt
@@ -14,7 +14,7 @@ import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.Play
 import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.RecordKey
 import io.palaima.debugdrawer.DebugDrawer
 import io.palaima.debugdrawer.base.DebugModuleAdapter
-import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxjava3.disposables.CompositeDisposable
 
 class MviCoreControlsModule(
     private val recordStore: PlaybackMiddleware.RecordStore

--- a/mvicore-demo/mvicore-demo-app/build.gradle
+++ b/mvicore-demo/mvicore-demo-app/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     implementation deps('com.android.support:design')
 
     // Rx
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxandroid')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxandroid')
 
     // DI
     implementation deps('com.google.dagger:dagger')

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/di/ScopedComponent.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/di/ScopedComponent.kt
@@ -1,7 +1,7 @@
 package com.badoo.mvicoredemo.di
 
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.disposables.Disposable
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.disposables.Disposable
 import java.lang.ref.WeakReference
 
 abstract class ScopedComponent<T : Any> {

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/di/appscope/module/MviCoreModule.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/di/appscope/module/MviCoreModule.kt
@@ -6,7 +6,7 @@ import com.badoo.mvicore.debugdrawer.MviCoreControlsModule
 import com.badoo.mvicoredemo.di.appscope.scope.AppScope
 import dagger.Module
 import dagger.Provides
-import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import timber.log.Timber
 
 @Module

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/di/usersessionscope/component/UserSessionScopedComponent.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/di/usersessionscope/component/UserSessionScopedComponent.kt
@@ -3,7 +3,7 @@ package com.badoo.mvicoredemo.di.usersessionscope.component
 import com.badoo.mvicoredemo.di.ScopedComponent
 import com.badoo.mvicoredemo.App
 import com.badoo.mvicoredemo.di.usersessionscope.module.FeatureModule
-import io.reactivex.disposables.Disposable
+import io.reactivex.rxjava3.disposables.Disposable
 
 object UserSessionScopedComponent : ScopedComponent<UserSessionComponent>() {
 

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/common/ObservableSourceActivity.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/common/ObservableSourceActivity.kt
@@ -1,9 +1,9 @@
 package com.badoo.mvicoredemo.ui.common
 
 import android.support.v7.app.AppCompatActivity
-import io.reactivex.ObservableSource
-import io.reactivex.Observer
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.core.Observer
+import io.reactivex.rxjava3.subjects.PublishSubject
 
 abstract class ObservableSourceActivity<T> : DebugActivity(), ObservableSource<T> {
 

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/lifecycle/LifecycleDemoActivity.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/lifecycle/LifecycleDemoActivity.kt
@@ -12,8 +12,8 @@ import com.badoo.mvicore.android.lifecycle.ResumePauseBinderLifecycle
 import com.badoo.mvicore.android.lifecycle.StartStopBinderLifecycle
 import com.badoo.mvicoredemo.R
 import init
-import io.reactivex.functions.Consumer
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.functions.Consumer
+import io.reactivex.rxjava3.subjects.PublishSubject
 import kotlinx.android.synthetic.main.activity_main.drawerLayout
 import kotlinx.android.synthetic.main.activity_main.navigationView
 import kotlinx.android.synthetic.main.activity_main.toolbar

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/main/MainActivity.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/main/MainActivity.kt
@@ -16,7 +16,7 @@ import com.badoo.mvicoredemo.ui.main.event.UiEvent.ImageClicked
 import com.badoo.mvicoredemo.ui.main.event.UiEvent.PlusClicked
 import com.badoo.mvicoredemo.ui.main.viewmodel.ViewModel
 import init
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 import kotlinx.android.synthetic.main.activity_main.button0
 import kotlinx.android.synthetic.main.activity_main.button1
 import kotlinx.android.synthetic.main.activity_main.button2

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/main/analytics/FakeAnalyticsTracker.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/main/analytics/FakeAnalyticsTracker.kt
@@ -3,7 +3,7 @@ package com.badoo.mvicoredemo.ui.main.analytics
 import android.content.Context
 import android.widget.Toast
 import com.badoo.mvicoredemo.ui.main.event.UiEvent
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 class FakeAnalyticsTracker(
     private val context: Context

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/main/news/NewsListener.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/ui/main/news/NewsListener.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.widget.Toast
 import com.badoo.feature2.Feature2
 import com.badoo.feature2.Feature2.News.ErrorExecutingRequest
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 import timber.log.Timber
 
 class NewsListener(

--- a/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/utils/RxExtensions.kt
+++ b/mvicore-demo/mvicore-demo-app/src/main/java/com/badoo/mvicoredemo/utils/RxExtensions.kt
@@ -1,8 +1,8 @@
 package com.badoo.mvicoredemo.utils
 
-import io.reactivex.Observable
-import io.reactivex.ObservableSource
-import io.reactivex.functions.BiFunction
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.BiFunction
 
 fun <T1, T2> combineLatest(o1: ObservableSource<T1>, o2: ObservableSource<T2>): ObservableSource<Pair<T1, T2>> =
     Observable.combineLatest(

--- a/mvicore-demo/mvicore-demo-catapi/build.gradle
+++ b/mvicore-demo/mvicore-demo-catapi/build.gradle
@@ -25,11 +25,11 @@ dependencies {
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation deps('com.android.support:appcompat-v7')
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxandroid')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxandroid')
 
     implementation deps('com.squareup.retrofit2:retrofit')
-    implementation deps('com.squareup.retrofit2:adapter-rxjava2')
+    implementation deps('com.github.akarnokd:rxjava3-retrofit-adapter')
     implementation deps('com.squareup.retrofit2:converter-simplexml')
 }
 

--- a/mvicore-demo/mvicore-demo-catapi/src/main/java/com/badoo/catapi/CatApi.kt
+++ b/mvicore-demo/mvicore-demo-catapi/src/main/java/com/badoo/catapi/CatApi.kt
@@ -1,11 +1,11 @@
 package com.badoo.catapi
 
-import io.reactivex.Observable
-import io.reactivex.schedulers.Schedulers
+import hu.akarnokd.rxjava3.retrofit.RxJava3CallAdapterFactory
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.schedulers.Schedulers
 import org.simpleframework.xml.convert.AnnotationStrategy
 import org.simpleframework.xml.core.Persister
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.simplexml.SimpleXmlConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -25,7 +25,7 @@ interface CatApi {
         private var retrofit = Retrofit.Builder()
             .baseUrl("https://thecatapi.com/api/")
             .addCallAdapterFactory(
-                RxJava2CallAdapterFactory.createWithScheduler(
+                RxJava3CallAdapterFactory.createWithScheduler(
                     Schedulers.io()
                 )
             )

--- a/mvicore-demo/mvicore-demo-feature1/build.gradle
+++ b/mvicore-demo/mvicore-demo-feature1/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation deps('com.android.support:appcompat-v7')
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxandroid')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxandroid')
 
     implementation project(":mvicore")
 }

--- a/mvicore-demo/mvicore-demo-feature2/build.gradle
+++ b/mvicore-demo/mvicore-demo-feature2/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation deps('com.android.support:appcompat-v7')
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxandroid')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxandroid')
 
     implementation project(":mvicore")
     implementation project(':mvicore-demo:mvicore-demo-catapi')

--- a/mvicore-demo/mvicore-demo-feature2/src/main/java/com/badoo/feature2/Extensions.kt
+++ b/mvicore-demo/mvicore-demo-feature2/src/main/java/com/badoo/feature2/Extensions.kt
@@ -1,6 +1,6 @@
 package com.badoo.feature2
 
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import java.util.concurrent.ThreadLocalRandom
 
 fun <T> Observable<T>.randomlyThrowAnException(): Observable<T> =

--- a/mvicore-demo/mvicore-demo-feature2/src/main/java/com/badoo/feature2/Feature2.kt
+++ b/mvicore-demo/mvicore-demo-feature2/src/main/java/com/badoo/feature2/Feature2.kt
@@ -17,9 +17,9 @@ import com.badoo.mvicore.element.NewsPublisher
 import com.badoo.mvicore.element.Reducer
 import com.badoo.mvicore.element.TimeCapsule
 import com.badoo.mvicore.feature.ActorReducerFeature
-import io.reactivex.Observable
-import io.reactivex.Observable.just
-import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Observable.just
 import kotlinx.android.parcel.Parcelize
 
 class Feature2(

--- a/mvicore-plugin/idea/build.gradle
+++ b/mvicore-plugin/idea/build.gradle
@@ -24,8 +24,8 @@ patchPluginXml {
 dependencies {
     def deps = rootProject.ext.deps
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxkotlin')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxkotlin')
     implementation deps('com.google.code.gson:gson')
     implementation project(':mvicore-plugin:common')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"

--- a/mvicore-plugin/middleware/build.gradle
+++ b/mvicore-plugin/middleware/build.gradle
@@ -8,8 +8,8 @@ archivesBaseName = 'mvicore-plugin-middleware'
 dependencies {
     def deps = rootProject.ext.deps
 
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxkotlin')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxkotlin')
     implementation deps('com.google.code.gson:gson')
     implementation project(':mvicore')
     implementation project(':mvicore-plugin:common')

--- a/mvicore-plugin/middleware/src/main/java/com/badoo/mvicore/middleware/DefaultPluginStore.kt
+++ b/mvicore-plugin/middleware/src/main/java/com/badoo/mvicore/middleware/DefaultPluginStore.kt
@@ -9,23 +9,23 @@ import com.badoo.mvicore.middleware.socket.PluginSocketThread
 import com.badoo.mvicore.plugin.model.ConnectionData
 import com.badoo.mvicore.plugin.model.Event
 import com.google.gson.GsonBuilder
-import io.reactivex.Observable
-import io.reactivex.Single
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.disposables.Disposable
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.schedulers.Schedulers
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.kotlin.plusAssign
+import io.reactivex.rxjava3.schedulers.Schedulers
+import io.reactivex.rxjava3.subjects.PublishSubject
 import java.lang.ref.ReferenceQueue
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.CopyOnWriteArrayList
 
 class DefaultPluginStore(
-    private val name: String,
-    port: Int = 7675,
-    private val elementsCacheSize: Int = 512,
-    private val disposables: CompositeDisposable = CompositeDisposable(),
-    ignoreOnSerialization: (Any?) -> Boolean = { false }
+        private val name: String,
+        port: Int = 7675,
+        private val elementsCacheSize: Int = 512,
+        private val disposables: CompositeDisposable = CompositeDisposable(),
+        ignoreOnSerialization: (Any?) -> Boolean = { false }
 ): IdeaPluginMiddleware.EventStore, Disposable by disposables {
     private val events = PublishSubject.create<Event>()
     private val socket = PluginSocketThread(port, elementsCacheSize * 2, events)

--- a/mvicore-plugin/middleware/src/main/java/com/badoo/mvicore/middleware/IdeaPluginMiddleware.kt
+++ b/mvicore-plugin/middleware/src/main/java/com/badoo/mvicore/middleware/IdeaPluginMiddleware.kt
@@ -2,11 +2,11 @@ package com.badoo.mvicore.middleware
 
 import com.badoo.binder.Connection
 import com.badoo.binder.middleware.base.Middleware
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 class IdeaPluginMiddleware<Out: Any, In: Any>(
-    wrapped: Consumer<In>,
-    private val store: EventStore
+        wrapped: Consumer<In>,
+        private val store: EventStore
 ): Middleware<Out, In>(wrapped) {
 
     override fun onBind(connection: Connection<Out, In>) {

--- a/mvicore-plugin/middleware/src/main/java/com/badoo/mvicore/middleware/socket/PluginSocketThread.kt
+++ b/mvicore-plugin/middleware/src/main/java/com/badoo/mvicore/middleware/socket/PluginSocketThread.kt
@@ -2,9 +2,9 @@ package com.badoo.mvicore.middleware.socket
 
 import com.badoo.mvicore.plugin.model.Event
 import com.google.gson.Gson
-import io.reactivex.Observable
-import io.reactivex.ObservableSource
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.subjects.PublishSubject
 import java.io.IOException
 import java.net.InetAddress
 import java.net.Socket
@@ -12,10 +12,10 @@ import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 
 internal class PluginSocketThread(
-    private val port: Int,
-    elementsCacheSize: Int,
-    private val events: Observable<Event>,
-    private val relay: PublishSubject<Connected> = PublishSubject.create()
+        private val port: Int,
+        elementsCacheSize: Int,
+        private val events: Observable<Event>,
+        private val relay: PublishSubject<Connected> = PublishSubject.create()
 ) : Thread("mvicore-plugin-socket"), ObservableSource<PluginSocketThread.Connected> by relay {
     private var socket: Socket? = null
     private val gson = Gson()

--- a/mvicore/build.gradle
+++ b/mvicore/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     def deps = rootProject.ext.deps
 
     api project(":binder")
-    implementation deps('io.reactivex.rxjava2:rxjava')
-    implementation deps('io.reactivex.rxjava2:rxkotlin')
+    implementation deps('io.reactivex.rxjava3:rxjava')
+    implementation deps('io.reactivex.rxjava3:rxkotlin')
     implementation deps("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
 
     testImplementation deps('junit:junit')

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/LoggingMiddleware.kt
@@ -3,13 +3,13 @@ package com.badoo.mvicore.consumer.middleware
 import com.badoo.binder.Connection
 import com.badoo.binder.middleware.base.Middleware
 import com.badoo.mvicore.consumer.util.Logger
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 import java.util.Locale
 
 class LoggingMiddleware<Out: Any, In: Any>(
-    wrapped: Consumer<In>,
-    private val logger: Logger,
-    private val config: Config = Config()
+        wrapped: Consumer<In>,
+        private val logger: Logger,
+        private val config: Config = Config()
 ) : Middleware<Out, In>(wrapped) {
 
     data class Config(

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/PlaybackMiddleware.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/middleware/PlaybackMiddleware.kt
@@ -3,13 +3,13 @@ package com.badoo.mvicore.consumer.middleware
 import com.badoo.binder.Connection
 import com.badoo.binder.middleware.base.Middleware
 import com.badoo.mvicore.consumer.util.Logger
-import io.reactivex.Observable
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.functions.Consumer
 
 open class PlaybackMiddleware<Out: Any, In: Any>(
-    wrapped: Consumer<In>,
-    private val recordStore: RecordStore,
-    private val logger: Logger? = null
+        wrapped: Consumer<In>,
+        private val recordStore: RecordStore,
+        private val logger: Logger? = null
 ) : Middleware<Out, In>(wrapped) {
 
     private var isInPlaybackMode: Boolean = false

--- a/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/consumer/playback/MemoryRecordStore.kt
@@ -11,9 +11,9 @@ import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.Play
 import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.PlaybackState.RECORDING
 import com.badoo.mvicore.consumer.middleware.PlaybackMiddleware.RecordStore.RecordKey
 import com.badoo.mvicore.consumer.util.Logger
-import io.reactivex.Observable
-import io.reactivex.Scheduler
-import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.subjects.BehaviorSubject
 import java.util.concurrent.TimeUnit
 
 class MemoryRecordStore(

--- a/mvicore/src/main/java/com/badoo/mvicore/element/Actor.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/Actor.kt
@@ -1,6 +1,6 @@
 package com.badoo.mvicore.element
 
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 
 typealias Actor<State, Action, Effect> =
     (state: State, action: Action) -> Observable<out Effect>

--- a/mvicore/src/main/java/com/badoo/mvicore/element/Bootstrapper.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/Bootstrapper.kt
@@ -1,5 +1,5 @@
 package com.badoo.mvicore.element
 
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 
 typealias Bootstrapper<Action> = () -> Observable<Action>

--- a/mvicore/src/main/java/com/badoo/mvicore/element/Store.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/Store.kt
@@ -1,7 +1,7 @@
 package com.badoo.mvicore.element
 
-import io.reactivex.ObservableSource
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.Consumer
 
 interface Store<Wish : Any, State : Any> : Consumer<Wish>, ObservableSource<State> {
 

--- a/mvicore/src/main/java/com/badoo/mvicore/extension/Rx.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/extension/Rx.kt
@@ -1,8 +1,8 @@
 package com.badoo.mvicore.extension
 
-import io.reactivex.Observable
-import io.reactivex.Observer
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Observer
+import io.reactivex.rxjava3.functions.Consumer
 
 @Deprecated(
     "Part of internal api, not supposed to be visible outside",

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
@@ -10,12 +10,12 @@ import com.badoo.mvicore.element.WishToAction
 import com.badoo.mvicore.extension.SameThreadVerifier
 import com.badoo.mvicore.extension.asConsumer
 import com.badoo.mvicore.feature.internal.DisposableCollection
-import io.reactivex.ObservableSource
-import io.reactivex.Observer
-import io.reactivex.functions.Consumer
-import io.reactivex.subjects.BehaviorSubject
-import io.reactivex.subjects.PublishSubject
-import io.reactivex.subjects.Subject
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.core.Observer
+import io.reactivex.rxjava3.functions.Consumer
+import io.reactivex.rxjava3.subjects.BehaviorSubject
+import io.reactivex.rxjava3.subjects.PublishSubject
+import io.reactivex.rxjava3.subjects.Subject
 
 open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any, News : Any>(
     initialState: State,
@@ -161,10 +161,10 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
     }
 
     private class ReducerWrapper<State : Any, Action : Any, Effect : Any>(
-        private val reducer: Reducer<State, Effect>,
-        private val states: Subject<State>,
-        private val postProcessorWrapper: Consumer<Triple<Action, Effect, State>>?,
-        private val newsPublisherWrapper: Consumer<Triple<Action, Effect, State>>?
+            private val reducer: Reducer<State, Effect>,
+            private val states: Subject<State>,
+            private val postProcessorWrapper: Consumer<Triple<Action, Effect, State>>?,
+            private val newsPublisherWrapper: Consumer<Triple<Action, Effect, State>>?
     ) : Consumer<Triple<State, Action, Effect>> {
 
         // record-playback entry point

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/Feature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/Feature.kt
@@ -1,8 +1,8 @@
 package com.badoo.mvicore.feature
 
 import com.badoo.mvicore.element.Store
-import io.reactivex.ObservableSource
-import io.reactivex.disposables.Disposable
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.disposables.Disposable
 
 interface Feature<Wish : Any, State : Any, News : Any> : Store<Wish, State>, Disposable {
 

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/ReducerFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/ReducerFeature.kt
@@ -5,8 +5,8 @@ import com.badoo.mvicore.element.Actor
 import com.badoo.mvicore.element.Bootstrapper
 import com.badoo.mvicore.element.NewsPublisher
 import com.badoo.mvicore.element.Reducer
-import io.reactivex.Observable
-import io.reactivex.Observable.just
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Observable.just
 
 open class ReducerFeature<Wish : Any, State : Any, News : Any>(
     initialState: State,

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/internal/DisposableCollection.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/internal/DisposableCollection.kt
@@ -1,6 +1,6 @@
 package com.badoo.mvicore.feature.internal
 
-import io.reactivex.disposables.Disposable
+import io.reactivex.rxjava3.disposables.Disposable
 
 internal class DisposableCollection : Disposable {
 

--- a/mvicore/src/test/java/com/badoo/mvicore/TestExtensions.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/TestExtensions.kt
@@ -1,6 +1,5 @@
 package com.badoo.mvicore
 
-import io.reactivex.observers.TestObserver
+import io.reactivex.rxjava3.observers.TestObserver
 
-fun <T> TestObserver<T>.onNextEvents() =
-        events[0]
+fun <T> TestObserver<T>.onNextEvents(): MutableList<T> = values()

--- a/mvicore/src/test/java/com/badoo/mvicore/TestHelper.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/TestHelper.kt
@@ -25,9 +25,9 @@ import com.badoo.mvicore.TestHelper.TestWish.Unfulfillable
 import com.badoo.mvicore.element.Actor
 import com.badoo.mvicore.element.NewsPublisher
 import com.badoo.mvicore.element.Reducer
-import io.reactivex.Observable
-import io.reactivex.Observable.just
-import io.reactivex.Scheduler
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Observable.just
+import io.reactivex.rxjava3.core.Scheduler
 import java.util.concurrent.TimeUnit
 
 class TestHelper {
@@ -124,7 +124,7 @@ class TestHelper {
             just(delayedFulfillAmount)
                 .delay(wish.delayMs, TimeUnit.MILLISECONDS, asyncWorkScheduler)
                 .map { FinishedAsync(it) as TestEffect }
-                .startWith(StartedAsync)
+                .startWith(just(StartedAsync))
 
         private fun emit3effects(): Observable<TestEffect> =
             just(

--- a/mvicore/src/test/java/com/badoo/mvicore/feature/BaseFeatureTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/feature/BaseFeatureTest.kt
@@ -19,9 +19,9 @@ import com.badoo.mvicore.TestHelper.TestWish.TranslatesTo3Effects
 import com.badoo.mvicore.TestHelper.TestWish.Unfulfillable
 import com.badoo.mvicore.extension.SameThreadVerifier
 import com.badoo.mvicore.onNextEvents
-import io.reactivex.observers.TestObserver
-import io.reactivex.schedulers.TestScheduler
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.observers.TestObserver
+import io.reactivex.rxjava3.schedulers.TestScheduler
+import io.reactivex.rxjava3.subjects.PublishSubject
 import org.junit.Before
 import org.junit.Test
 import org.mockito.MockitoAnnotations

--- a/mvicore/src/test/java/com/badoo/mvicore/newspublishing/NewsPublishingTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/newspublishing/NewsPublishingTest.kt
@@ -21,9 +21,9 @@ import com.nhaarman.mockito_kotlin.spy
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
-import io.reactivex.Observable
-import io.reactivex.functions.Consumer
-import io.reactivex.observers.TestObserver
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.functions.Consumer
+import io.reactivex.rxjava3.observers.TestObserver
 import org.amshove.kluent.any
 import org.amshove.kluent.mock
 import org.junit.After


### PR DESCRIPTION
Migrated to RxJava 3 versions from v2 in library and sample project, as RxJava2 is in maintenance mode.
 
**io.reactivex.rxjava3:rxjava:3.0.6
io.reactivex.rxjava3:rxkotlin:3.0.1          
io.reactivex.rxjava3:rxandroid:3.0.0**    

Also updated Retrofit version to **2.9.0** and used **com.github.akarnokd:rxjava3-retrofit-adapter:3.0.0** for demo app. 