### PR TITLE
Mockito-kotlin dependency updated

### DIFF
--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     testImplementation deps('junit:junit')
     testImplementation deps('org.jetbrains.kotlin:kotlin-test-junit')
-    testImplementation deps('com.nhaarman:mockito-kotlin')
+    testImplementation deps('org.mockito.kotlin:mockito-kotlin')
 }
 
 sourceCompatibility = "1.7"

--- a/binder/src/test/java/com/badoo/binder/LifecycleTest.kt
+++ b/binder/src/test/java/com/badoo/binder/LifecycleTest.kt
@@ -2,14 +2,14 @@ package com.badoo.binder
 
 import com.badoo.binder.lifecycle.Lifecycle
 import com.badoo.binder.lifecycle.ManualLifecycle
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
 import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 import io.reactivex.subjects.PublishSubject
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 
 
 class LifecycleTest {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
     junitVersion = '4.12'
     kluentVersion = '1.23'
     supportTestVersion = '1.3.0'
-    mockitoKotlinVersion = '1.3.0'
+    mockitoKotlinVersion = '3.2.0'
 
     depsWithVersion = [
             // Kotlin
@@ -100,7 +100,7 @@ ext {
             "junit:junit"                                       : junitVersion,
             "org.jetbrains.kotlin:kotlin-test-junit"            : kotlinVersion,
             "org.amshove.kluent:kluent"                         : kluentVersion,
-            "com.nhaarman:mockito-kotlin"                       : mockitoKotlinVersion,
+            "org.mockito.kotlin:mockito-kotlin"                 : mockitoKotlinVersion,
             "androidx.test:runner"                              : supportTestVersion,
             "androidx.test:orchestrator"                        : supportTestVersion,
             "androidx.test:rules"                               : supportTestVersion,

--- a/mvicore/build.gradle
+++ b/mvicore/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation deps('junit:junit')
     testImplementation deps('org.jetbrains.kotlin:kotlin-test-junit')
     testImplementation deps('org.amshove.kluent:kluent')
-    testImplementation deps('com.nhaarman:mockito-kotlin')
+    testImplementation deps('org.mockito.kotlin:mockito-kotlin')
 }
 
 sourceCompatibility = "1.7"

--- a/mvicore/src/test/java/com/badoo/mvicore/newspublishing/NewsPublishingTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/newspublishing/NewsPublishingTest.kt
@@ -27,7 +27,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
-import org.mockito.kotlin.*
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 
 sealed class TestWish {

--- a/mvicore/src/test/java/com/badoo/mvicore/newspublishing/NewsPublishingTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/newspublishing/NewsPublishingTest.kt
@@ -16,11 +16,6 @@ import com.badoo.mvicore.newspublishing.TestNews.News3
 import com.badoo.mvicore.newspublishing.TestWish.Wish1
 import com.badoo.mvicore.newspublishing.TestWish.Wish2
 import com.badoo.mvicore.newspublishing.TestWish.Wish3
-import com.nhaarman.mockito_kotlin.argumentCaptor
-import com.nhaarman.mockito_kotlin.spy
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver
@@ -32,6 +27,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
+import org.mockito.kotlin.*
 import kotlin.test.assertEquals
 
 sealed class TestWish {


### PR DESCRIPTION
### Changes:
- Updated mockito-kotlin library to `org.mockito.kotlin:mockito-kotlin:3.2.0`
- Fixed imports in `NewsPublishingTest.kt` and `LifecycleTest.kt`
