### PR TITLE
Fixed Bootstrapper variance

### DIFF
--- a/mvicore-demo/mvicore-demo-feature2/src/main/java/com/badoo/feature2/Feature2.kt
+++ b/mvicore-demo/mvicore-demo-feature2/src/main/java/com/badoo/feature2/Feature2.kt
@@ -50,7 +50,7 @@ class Feature2(
     sealed class Effect {
         object StartedLoading : Effect()
         data class LoadedImage(val url: String) : Effect()
-        data class ErrorLoading(val throwable : Throwable) : Effect()
+        data class ErrorLoading(val throwable: Throwable) : Effect()
     }
 
     sealed class News {
@@ -58,7 +58,7 @@ class Feature2(
     }
 
     class BootStrapperImpl : Bootstrapper<Wish> {
-        override fun invoke(): Observable<Wish> = just(LoadNewImage)
+        override fun invoke(): Observable<out Wish> = just(LoadNewImage)
     }
 
     class ActorImpl : Actor<State, Wish, Effect> {

--- a/mvicore/src/main/java/com/badoo/mvicore/element/Bootstrapper.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/element/Bootstrapper.kt
@@ -2,4 +2,4 @@ package com.badoo.mvicore.element
 
 import io.reactivex.Observable
 
-typealias Bootstrapper<Action> = () -> Observable<Action>
+typealias Bootstrapper<Action> = () -> Observable<out Action>


### PR DESCRIPTION
Now, when I want to do something like this:
```kotlin
private class BootstrapperImpl(
    private val dataSource: DataSource,
) : Bootstrapper<Action> {
    override fun invoke(): Observable<Action> =
        dataSource
            .observe()
            .map { Action.NameChanged(it.name) }
            .distinctUntilChanged()
}
```

I need to explicitly specify `.map` generic type:
```kotlin
.map<Action> { Action.NameChanged(it.name) }
.distinctUntilChanged()
```

So, generic `Action` in `Bootstrapper` should be covariant (like `Actor`) to be more flexible in such cases