### PR TITLE
Async actor improvements

### DIFF
--- a/mvicore/src/main/java/com/badoo/mvicore/feature/ActorReducerFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/ActorReducerFeature.kt
@@ -10,12 +10,14 @@ open class ActorReducerFeature<Wish : Any, in Effect : Any, State : Any, News : 
     bootstrapper: Bootstrapper<Wish>? = null,
     actor: Actor<State, Wish, Effect>,
     reducer: Reducer<State, Effect>,
-    newsPublisher: NewsPublisher<Wish, Effect, State, News>? = null
+    newsPublisher: NewsPublisher<Wish, Effect, State, News>? = null,
+    schedulers: FeatureSchedulers? = null
 ) : BaseFeature<Wish, Wish, Effect, State, News>(
     initialState = initialState,
     bootstrapper = bootstrapper,
     wishToAction = { wish -> wish },
     actor = actor,
     reducer = reducer,
-    newsPublisher = newsPublisher
+    newsPublisher = newsPublisher,
+    schedulers = schedulers
 )

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
@@ -33,7 +33,7 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
     reducer: Reducer<State, Effect>,
     postProcessor: PostProcessor<Action, Effect, State>? = null,
     newsPublisher: NewsPublisher<Action, Effect, State, News>? = null,
-    private val schedulers: Schedulers? = null
+    private val schedulers: FeatureSchedulers? = null
 ) : AsyncFeature<Wish, State, News> {
 
     private val threadVerifier by lazy { SameThreadVerifier() }
@@ -289,10 +289,4 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
             }
         }
     }
-
-    class Schedulers(
-        /** Should be single-threaded. */
-        val featureScheduler: Scheduler,
-        val observationScheduler: Scheduler
-    )
 }

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/FeatureSchedulers.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/FeatureSchedulers.kt
@@ -1,0 +1,12 @@
+package com.badoo.mvicore.feature
+
+import io.reactivex.Scheduler
+
+/**
+ * A set of [Scheduler]s that change the threading behaviour of a [Feature]
+ */
+class FeatureSchedulers(
+    /** Should be single-threaded. */
+    val featureScheduler: Scheduler,
+    val observationScheduler: Scheduler
+)

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/MemoFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/MemoFeature.kt
@@ -1,8 +1,10 @@
 package com.badoo.mvicore.feature
 
 open class MemoFeature<State : Any>(
-    initialState: State
+    initialState: State,
+    schedulers: FeatureSchedulers? = null
 ) : Feature<State, State, Nothing> by ReducerFeature<State, State, Nothing>(
     initialState = initialState,
-    reducer = { _, effect -> effect }
+    reducer = { _, effect -> effect },
+    schedulers = schedulers
 )

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/ReducerFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/ReducerFeature.kt
@@ -12,14 +12,16 @@ open class ReducerFeature<Wish : Any, State : Any, News : Any>(
     initialState: State,
     reducer: Reducer<State, Wish>,
     bootstrapper: Bootstrapper<Wish>? = null,
-    newsPublisher: SimpleNewsPublisher<Wish, State, News>? = null
+    newsPublisher: SimpleNewsPublisher<Wish, State, News>? = null,
+    schedulers: FeatureSchedulers? = null
 ) : BaseFeature<Wish, Wish, Wish, State, News>(
     initialState = initialState,
     bootstrapper = bootstrapper,
     wishToAction = { wish -> wish },
     actor = BypassActor(),
     reducer = reducer,
-    newsPublisher = newsPublisher
+    newsPublisher = newsPublisher,
+    schedulers = schedulers
 ) {
     class BypassActor<in State : Any, Wish : Any> : Actor<State, Wish, Wish>, NonWrappable {
         override fun invoke(state: State, wish: Wish): Observable<Wish> =

--- a/mvicore/src/test/java/com/badoo/mvicore/feature/AsyncBaseFeatureTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/feature/AsyncBaseFeatureTest.kt
@@ -193,7 +193,7 @@ class AsyncBaseFeatureTest {
         newsPublisher = newsPublisher,
         postProcessor = postProcessor,
         schedulers = if (featureScheduler != null && observationScheduler != null) {
-            BaseFeature.Schedulers(
+            FeatureSchedulers(
                 featureScheduler = featureScheduler,
                 observationScheduler = observationScheduler
             )


### PR DESCRIPTION
Made a few changes to the recent async actor change introduced last week.
- Renamed the `BaseFeature.Schedulers` class to `FeatureSchedulers`
  - This caused a compilation issue with existing 'legacy' features that pass in a scheduler as there is a name conflict between the imports.
- Added the new schedulers to the `BaseFeature` subtypes.