### PR TITLE
Changed to Java 8 compatibility to fix build

### DIFF
--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -33,6 +33,12 @@ dependencies {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+}
+
 task packageSources(type: Jar, dependsOn: 'classes') {
     classifier = 'sources'
     from sourceSets.main.allSource

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     testImplementation deps('org.mockito.kotlin:mockito-kotlin')
 }
 
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 task packageSources(type: Jar, dependsOn: 'classes') {
     classifier = 'sources'

--- a/mvicore-android/build.gradle
+++ b/mvicore-android/build.gradle
@@ -26,6 +26,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/mvicore-debugdrawer/build.gradle
+++ b/mvicore-debugdrawer/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation project(':mvicore')
 }
 
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 buildscript {
     repositories {

--- a/mvicore-debugdrawer/build.gradle
+++ b/mvicore-debugdrawer/build.gradle
@@ -21,6 +21,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -44,9 +53,6 @@ dependencies {
 
     implementation project(':mvicore')
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
 
 buildscript {
     repositories {

--- a/mvicore-demo/mvicore-demo-app/build.gradle
+++ b/mvicore-demo/mvicore-demo-app/build.gradle
@@ -26,6 +26,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/mvicore-demo/mvicore-demo-catapi/build.gradle
+++ b/mvicore-demo/mvicore-demo-catapi/build.gradle
@@ -19,6 +19,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/mvicore-demo/mvicore-demo-feature1/build.gradle
+++ b/mvicore-demo/mvicore-demo-feature1/build.gradle
@@ -20,6 +20,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 androidExtensions {

--- a/mvicore-demo/mvicore-demo-feature2/build.gradle
+++ b/mvicore-demo/mvicore-demo-feature2/build.gradle
@@ -20,6 +20,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 androidExtensions {

--- a/mvicore-diff/build.gradle
+++ b/mvicore-diff/build.gradle
@@ -52,11 +52,11 @@ artifacts {
 }
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.6"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.6"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }

--- a/mvicore-diff/build.gradle
+++ b/mvicore-diff/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     testImplementation deps('org.jetbrains.kotlin:kotlin-test-junit')
 }
 
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     jcenter()

--- a/mvicore-plugin/common/build.gradle
+++ b/mvicore-plugin/common/build.gradle
@@ -39,11 +39,11 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }

--- a/mvicore-plugin/common/build.gradle
+++ b/mvicore-plugin/common/build.gradle
@@ -34,8 +34,8 @@ artifacts {
     archives packageJavadoc
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 compileKotlin {
     kotlinOptions {

--- a/mvicore-plugin/idea/build.gradle
+++ b/mvicore-plugin/idea/build.gradle
@@ -49,7 +49,7 @@ task packageSources(type: Jar, dependsOn: 'classes') {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 

--- a/mvicore-plugin/middleware/build.gradle
+++ b/mvicore-plugin/middleware/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     jcenter()

--- a/mvicore-plugin/middleware/build.gradle
+++ b/mvicore-plugin/middleware/build.gradle
@@ -53,11 +53,11 @@ buildscript {
 }
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }

--- a/mvicore/build.gradle
+++ b/mvicore/build.gradle
@@ -21,6 +21,12 @@ dependencies {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+}
+
 buildscript {
     repositories {
         jcenter()

--- a/mvicore/build.gradle
+++ b/mvicore/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     testImplementation deps('org.mockito.kotlin:mockito-kotlin')
 }
 
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 buildscript {
     repositories {


### PR DESCRIPTION
Fixes a regression in the build (caught by github actions) where the running AndroidTests was failing due to an issue with desugaring:

> * What went wrong:
> Execution failed for task ':mvicore-demo:mvicore-demo-feature2:mergeExtDexDebugAndroidTest'.
> > Could not resolve all files for configuration ':mvicore-demo:mvicore-demo-feature2:debugAndroidTestRuntimeClasspath'.
>    > Failed to transform lifecycle-common-java8-2.2.0.jar (androidx.lifecycle:lifecycle-common-java8:2.2.0) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-incremental-transform=false, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}.
>       > Execution failed for DexingNoClasspathTransform: /Users/runner/.gradle/caches/modules-2/files-2.1/androidx.lifecycle/lifecycle-common-java8/2.2.0/cd3478503da69b1a7e0319bd2d1389943db9b364/lifecycle-common-java8-2.2.0.jar.
>          > Error while dexing.
>            The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
>            android {
>                compileOptions {
>                    sourceCompatibility 1.8
>                    targetCompatibility 1.8
>                }
>            }
>            See https://developer.android.com/studio/write/java8-support.html for details. Alternatively, increase the minSdkVersion to 24 or above.