### PR TITLE
Improved SameThreadVerifier error message

### DIFF
--- a/mvicore/src/main/java/com/badoo/mvicore/extension/SameThreadVerifier.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/extension/SameThreadVerifier.kt
@@ -6,14 +6,21 @@ class SameThreadVerifier(private val clazz: Class<*>) {
         var isEnabled : Boolean = true
     }
 
-    private val originalThread = Thread.currentThread()
+    private val originalThreadId: Long
+    private val originalThreadName: String
+
+    init {
+        val currentThread = Thread.currentThread()
+        originalThreadId = currentThread.id
+        originalThreadName = currentThread.name
+    }
 
     fun verify() {
         val currentThread = Thread.currentThread()
-        if (isEnabled && (currentThread.id != originalThread.id)) {
+        if (isEnabled && (currentThread.id != originalThreadId)) {
             throw AssertionError(
                 "${clazz.name} was interacted with on the wrong thread. " +
-                        "Expected: '${originalThread.name}', Actual: '${currentThread.name}'"
+                        "Expected: '$originalThreadName', Actual: '${currentThread.name}'"
             )
         }
     }

--- a/mvicore/src/main/java/com/badoo/mvicore/extension/SameThreadVerifier.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/extension/SameThreadVerifier.kt
@@ -1,16 +1,20 @@
 package com.badoo.mvicore.extension
 
-class SameThreadVerifier {
+class SameThreadVerifier(private val clazz: Class<*>) {
 
     companion object {
         var isEnabled : Boolean = true
     }
 
-    private val originalThread = Thread.currentThread().id
+    private val originalThread = Thread.currentThread()
 
     fun verify() {
-        if (isEnabled && (Thread.currentThread().id != originalThread)) {
-            throw AssertionError("Not on same thread as previous verification")
+        val currentThread = Thread.currentThread()
+        if (isEnabled && (currentThread.id != originalThread.id)) {
+            throw AssertionError(
+                "${clazz.name} was interacted with on the wrong thread. " +
+                        "Expected: '${originalThread.name}', Actual: '${currentThread.name}'"
+            )
         }
     }
 

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseAsyncFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseAsyncFeature.kt
@@ -33,7 +33,7 @@ open class BaseAsyncFeature<Wish : Any, in Action : Any, in Effect : Any, State 
     private val schedulers: AsyncFeatureSchedulers
 ) : AsyncFeature<Wish, State, News> {
 
-    private val threadVerifier by lazy { SameThreadVerifier() }
+    private val threadVerifier by lazy { SameThreadVerifier(javaClass) }
     private val actionSubject = PublishSubject.create<Action>().toSerialized()
     // store last state to make best effort to return it in getState()
     private val lastState = AtomicReference<State>(initialState)

--- a/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
+++ b/mvicore/src/main/java/com/badoo/mvicore/feature/BaseFeature.kt
@@ -46,7 +46,7 @@ open class BaseFeature<Wish : Any, in Action : Any, in Effect : Any, State : Any
     private val featureScheduler: FeatureScheduler? = null
 ) : Feature<Wish, State, News> {
 
-    private val threadVerifier = if (featureScheduler == null) SameThreadVerifier() else null
+    private val threadVerifier = if (featureScheduler == null) SameThreadVerifier(javaClass) else null
     private val actionSubject = PublishSubject.create<Action>().toSerialized()
     private val stateSubject = BehaviorSubject.createDefault(initialState)
     private val newsSubject = PublishSubject.create<News>()

--- a/mvicore/src/test/java/com/badoo/mvicore/extension/SameThreadVerifierTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/extension/SameThreadVerifierTest.kt
@@ -1,0 +1,39 @@
+package com.badoo.mvicore.extension
+
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+internal class SameThreadVerifierTest {
+    @Test
+    fun `GIVEN same thread WHEN verify THEN expect no exceptions`() {
+        val threadVerifier = SameThreadVerifier(String::class.java)
+        threadVerifier.verify()
+    }
+
+    @Test
+    fun `GIVEN different thread WHEN verify THEN expect exception`() {
+        val threadVerifier = SameThreadVerifier(String::class.java)
+        val testWorkerThreadName = Thread.currentThread().name
+
+        var assertionError: AssertionError? = null
+        val latch = CountDownLatch(1)
+        thread(name = "wrong-thread") {
+            try {
+                threadVerifier.verify()
+            } catch (e: AssertionError) {
+                assertionError = e
+            }
+            latch.countDown()
+        }
+        latch.await()
+
+        assertNotNull(assertionError)
+        assertEquals(
+            "java.lang.String was interacted with on the wrong thread. Expected: '$testWorkerThreadName', Actual: 'wrong-thread'",
+            assertionError!!.message
+        )
+    }
+}

--- a/mvicore/src/test/java/com/badoo/mvicore/extension/SameThreadVerifierTest.kt
+++ b/mvicore/src/test/java/com/badoo/mvicore/extension/SameThreadVerifierTest.kt
@@ -2,6 +2,7 @@ package com.badoo.mvicore.extension
 
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -28,7 +29,7 @@ internal class SameThreadVerifierTest {
             }
             latch.countDown()
         }
-        latch.await()
+        latch.await(1, TimeUnit.SECONDS)
 
         assertNotNull(assertionError)
         assertEquals(


### PR DESCRIPTION
Improves the SameThreadVerifier error message, allowing a developer to easily see which feature the error occurred on, and what the thread names are.