### PR TITLE
Fixed mkdocs logo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ copyright: 'Copyright &copy; 2020 Badoo Trading Limited'
 theme:
   name: 'material'
   favicon: 'https://badoo.com/favicon.ico'
-  logo:
-    icon: 'code'
+  icon:
+    logo: 'material/code-tags'
   palette:
     primary: 'deep purple'
     accent: 'pink'


### PR DESCRIPTION
## Description
The material logo was causing the documentation to not build. I have updated it to the correct path.

## Check list

- [x] I have updated `whatsnew.md` if required.
- [x] I have updated documentation if required.
