### PR TITLE
Use detekt.basePath instead of changing paths manually

### DIFF
--- a/plugins/verification-plugin/src/main/kotlin/CollectSarifPlugin.kt
+++ b/plugins/verification-plugin/src/main/kotlin/CollectSarifPlugin.kt
@@ -2,7 +2,6 @@ import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
-import java.io.File
 
 class CollectSarifPlugin : Plugin<Project> {
 
@@ -14,21 +13,6 @@ class CollectSarifPlugin : Plugin<Project> {
         target.tasks.register(MERGE_DETEKT_TASK_NAME, ReportMergeTask::class.java) {
             group = JavaBasePlugin.VERIFICATION_GROUP
             output.set(project.layout.buildDirectory.file("detekt-merged.sarif"))
-            fixDetektSarif()
-        }
-    }
-
-    private fun ReportMergeTask.fixDetektSarif() {
-        doLast {
-            val rootDir = project.rootProject.rootDir.absolutePath
-            val outputFile = output.asFile.get()
-            var content = outputFile.readText()
-            // detekt uses full paths to files instead of relative ones with (originalUriBaseIds + uriBaseId)
-            // code scanning tools can't understand full paths because are run on a different machine
-            if (!content.contains("originalUriBaseIds")) {
-                content = content.replace(rootDir + File.separator, "")
-                outputFile.writeText(content)
-            }
         }
     }
 

--- a/plugins/verification-plugin/src/main/kotlin/DetektPlugin.kt
+++ b/plugins/verification-plugin/src/main/kotlin/DetektPlugin.kt
@@ -10,9 +10,12 @@ class DetektPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("io.gitlab.arturbosch.detekt")
         target.plugins.withId("io.gitlab.arturbosch.detekt") {
+            val rootProject = target.rootProject
+
             target.extensions.configure<DetektExtension> {
                 buildUponDefaultConfig = true
                 baseline = target.file("detekt-baseline.xml")
+                basePath = rootProject.projectDir.absolutePath
 
                 val localDetektConfig = target.file("detekt.yml")
                 val rootDetektConfig = target.rootProject.file("detekt.yml")
@@ -28,7 +31,6 @@ class DetektPlugin : Plugin<Project> {
                 reports.sarif.required.set(true)
             }
 
-            val rootProject = target.rootProject
             rootProject.plugins.withId("mvi-core-collect-sarif") {
                 rootProject.tasks.named(
                     CollectSarifPlugin.MERGE_DETEKT_TASK_NAME,


### PR DESCRIPTION
## Description
SARIFs basePath property is properly supported by Detekt, we do not need this fix.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
