### PR TITLE
Introduced LifecycleExtensions overloads to set observation schedulers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 #### Additions
 
+([#179](https://github.com/badoo/MVICore/pull/179)):
+Introduced the ability to specify observation scheduler within the `Binder` class (see the `observeOn` DSL below), as well as the `observeOn` infix operator for `Connection` class (related to `Binder`).
+
+An example of how you might use this is as follows:
+
+```kotlin
+// mvicore-android example
+testLifecycleOwner.lifecycle.createDestroy {
+    observeOn(mainScheduler) {
+        bind(events to uiConsumer1)
+        bind(events to uiConsumer2)
+    }
+    observeOn(backgroundScheduler) {
+        bind(events to backgroundConsumer1)
+        bind(events to backgroundConsumer2)
+    }
+    bind(events to uiConsumer3 observeOn mainScheduler)
+    bind(events to backgroundConsumer3 observeOn backgroundScheduler)
+}
+
+// binder example
+binder.observeOn(mainScheduler) {
+    bind(events to uiConsumer1)
+    bind(events to uiConsumer2)
+}
+```
+
+See more details in [advanced binder](../binder/binder-advanced/#setting-connections-observation-scheduler) section.
+
 ([#177](https://github.com/badoo/MVICore/pull/177)):
 Updated AndroidX appcompat to 1.4.1 and lifecycle to 2.5.1. Also updated Compile and Target SDK to API 33.
 

--- a/binder/src/main/java/com/badoo/binder/Connection.kt
+++ b/binder/src/main/java/com/badoo/binder/Connection.kt
@@ -3,13 +3,15 @@ package com.badoo.binder
 import com.badoo.binder.connector.Connector
 import com.badoo.binder.connector.NotNullConnector
 import io.reactivex.ObservableSource
+import io.reactivex.Scheduler
 import io.reactivex.functions.Consumer
 
 data class Connection<Out, In>(
     val from: ObservableSource<out Out>? = null,
     val to: Consumer<in In>,
     val connector: Connector<Out, In>? = null,
-    val name: String? = null
+    val name: String? = null,
+    val observeScheduler: Scheduler? = null,
 ) {
     companion object {
         private const val ANONYMOUS: String = "anonymous"
@@ -39,7 +41,19 @@ infix fun <T> Pair<ObservableSource<out T>, Consumer<in T>>.named(name: String):
         name = name
     )
 
+infix fun <T> Pair<ObservableSource<out T>, Consumer<in T>>.observeOn(scheduler: Scheduler): Connection<T, T> =
+    Connection(
+        from = first,
+        to = second,
+        observeScheduler = scheduler
+    )
+
 infix fun <Out, In> Connection<Out, In>.named(name: String) =
     copy(
         name = name
+    )
+
+infix fun <Out, In> Connection<Out, In>.observeOn(scheduler: Scheduler) =
+    copy(
+        observeScheduler = scheduler
     )

--- a/documentation/binder/binder-advanced.md
+++ b/documentation/binder/binder-advanced.md
@@ -37,7 +37,7 @@ binder.bind(output to input using OutputToInput)
 
 ## Naming connections
 
-And you can optionally give names to any connection:
+You can optionally give names to any connection:
 ```kotlin
 binder.bind(input to output named "MyConnection")
 // or
@@ -49,3 +49,20 @@ Naming a connection signals that it's important to you. This will make more sens
 - You'll see connections with their respective names in the time-travel debug menu
 - You'll see connection names in logs if you use LoggingMiddleware
 - You can opt to dynamically add `Middlewares` only to named connections (if that's what you want)
+
+## Setting connections observation scheduler
+
+You can optionally set the observation scheduler for any connection:
+```kotlin
+binder.bind(input to output observeOn scheduler)
+```
+
+You can also use `Binder.observeOn` to reduce repetition:
+```kotlin
+binder.observeOn(scheduler) {
+    bind(input1 to output1)
+    bind(input2 to output2)
+}
+```
+
+Specifying an observation scheduler ensures that the output is called on the specified scheduler.


### PR DESCRIPTION
## Description
Proposal for allowing developers to set observation scheduler for Binder and lifecycle extensions.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
