### PR TITLE
Use older macos agent to support Android emulator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    runs-on: macOS-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
             ./gradlew connectedCheck
       - name: Upload failed instrumentation artifacts
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: instrumentation-failures
           path: |


### PR DESCRIPTION
## Description

See https://github.com/ReactiveCircus/android-emulator-runner/issues/386

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
